### PR TITLE
Fix README to use browser.umd.js for prototype helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See the [dotnet/src/README.md](dotnet/src/README.md) file for more details.
 > **Note**
 > This method is not intended to be used in production
 
-If you include the `index.js` within your prototype’s `body` element (`<script src="https://unpkg.com/@stackoverflow/stacks-icons"></script>`) you can render Stacks Icons in the browser using only the following format:
+If you include the `browser.umd.js` within your prototype’s `body` element (`<script src="https://unpkg.com/@stackoverflow/stacks-icons/dist/browser.umd.js"></script>`) you can render Stacks Icons in the browser using only the following format:
 
 ```html
 <svg data-icon="IconFaceMindBlown" class="native"></svg>


### PR DESCRIPTION
I was making a prototype today and noticed the browser helper JS wasn't working. I think since ab622f7aa32e387568be3e84e888ab7c10909a76, prototypes need to use the `browser.umd.js` script instead of `index.js`. This is what the [CodePen template](https://codepen.io/pen?template=wvmRgdp) seems to use at least.

Using `browser.umd.js` seems to be working for me and includes the browser helper bits that were missing in the `index.js` file.