### PR TITLE
fix(forced-colors): override forced colors on bg svg

### DIFF
--- a/src/icons.css
+++ b/src/icons.css
@@ -21,6 +21,7 @@
     mask: var(--bg-icon) no-repeat center;
     -webkit-mask-size: contain;
     mask-size: contain;
+    forced-color-adjust: none;
 }
 
 /* in order to support "native" coloring of an icon, */


### PR DESCRIPTION
This PR adds `forced-color-adjust: none;` to icon pseudo-elements that render the icon as the background image. This is to ensure that the icon renders visibly in forced color modes (most notably in Windows high contrast mode).

### Testing

1. Build with `npm run build`
2. Preview with `npm run preview`
3. Open the preview in Chrome
4. Scroll down to the **CSS Icons** section at the bottom of the preview page 
5. Open the inspector
6. Open the inspector command palette and emulate forced color modes ([detailed instructions](https://devtoolstips.org/tips/en/emulate-forced-colors/))
7. Note that all CSS Icons remain visible (prior to this PR, only the icons with `.native` would stay visible)


### Before

![image](https://github.com/StackExchange/Stacks-Icons/assets/647177/9bb0c04e-2fcb-49de-82d3-ffd21d92e6f1)

### After

![image](https://github.com/StackExchange/Stacks-Icons/assets/647177/17a6cab2-7471-4cc9-8233-c9a2bf452e4d)
