### PR TITLE
fix(forced-colors): override forced colors on bg svg with CanvasText

### DIFF
--- a/src/icons.css
+++ b/src/icons.css
@@ -21,7 +21,12 @@
     mask: var(--bg-icon) no-repeat center;
     -webkit-mask-size: contain;
     mask-size: contain;
-    forced-color-adjust: none;
+}
+
+@media (forced-colors: active) {
+    .svg-icon-bg::after {
+        background-color: CanvasText;
+    }
 }
 
 /* in order to support "native" coloring of an icon, */


### PR DESCRIPTION
See https://github.com/StackExchange/Stacks-Icons/pull/270#issuecomment-1947937132

@giamir I misinterpreted your [original suggestion](https://github.com/StackExchange/Stacks-Icons/pull/270#issuecomment-1935983790) to use `background-color: CanvasText;` with a media query. Thanks for [reiterating](https://github.com/StackExchange/Stacks-Icons/pull/270#issuecomment-1947937132). This PR implements your suggestion.