### PR TITLE
chore(deps): remove html abstractions package

### DIFF
--- a/dotnet/src/StackExchange.StacksIcons.csproj
+++ b/dotnet/src/StackExchange.StacksIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 		<Version>6.0.2</Version>
 		<AssemblyName>StackExchange.StacksIcons</AssemblyName>
 		<PackageId>StackExchange.StacksIcons</PackageId>
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />
 	</ItemGroup>


### PR DESCRIPTION
This PR removes the outdated `Microsoft.AspNetCore.Html.Abstractions` and change the target frameworks to dotnet core 6 and 8.
[More info about the deprecation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/target-aspnetcore?view=aspnetcore-8.0&tabs=visual-studio#use-the-aspnet-core-shared-framework)

[Slack thread](https://stackexchange.slack.com/archives/CNAE3JWEP/p1717740693778209)