### PR TITLE
feat(icons): simplified variant naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ npm run test:nuget
 
 All icons and spots are pulled directly from Figma via their API. The _only_ way to add or update icons is by directly modifying the [source Figma file](https://www.figma.com/file/Z5yoO4WH58QDHvmxwMWhr0) and then publishing a new component release from within Figma.
 
+### Sorting the config.yaml
+
+To maintain readability you can format and sort the config yaml by using the command.
+
+```sh
+brew install yq # if you haven't already installed it
+npm run format:config
+```
+
 #### Publishing an icon
 
 In order to expose a new icon to this repository, you'll need to convert it into a component then publish it by following these steps:

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Using the library by `import`ing a subpath (e.g. `/icons`) will allow for tree-s
 
 ```js
 // es6 / module syntax
-import { IconAnswer20Duotone } from "@stackoverflow/stacks-icons/icons";
+import { IconAnswer } from "@stackoverflow/stacks-icons/icons";
 import { SpotWave } from "@stackoverflow/stacks-icons/spots";
 
 // both icons and spots are unescaped html strings
-console.log(IconAnswer20Duotone); // "<svg>...</svg>"
+console.log(IconAnswer); // "<svg>...</svg>"
 
 // require() syntax
 const { Icons, Spots } = require("@stackoverflow/stacks-icons");
 
 // `Icons` and `Spots` are objects mapped by <icon name, html string>
-console.log(Icons); // { "IconAnswer20Duotone": "<svg>...</svg>", ... }
+console.log(Icons); // { "IconAnswer": "<svg>...</svg>", ... }
 ```
 
 ### Using the CSS icons
@@ -39,13 +39,13 @@ In certain cases where adding the raw svg markup to your html would cause bloat 
 />
 
 <!-- add the "svg-icon-bg" class in addition the desired "iconNAME" class -->
-<span class="svg-icon-bg iconAnswer20Duotone"></span>
+<span class="svg-icon-bg iconAnswer"></span>
 
 <!-- the icon's color matches the "currentColor", so changing the "color" property will change the icon color -->
-<span class="svg-icon-bg iconAnswer20Duotone" style="color: red;"></span>
+<span class="svg-icon-bg iconAnswer" style="color: red;"></span>
 
 <!-- add the "native" class to get native styles; these do not respect "currentColor" changes -->
-<span class="svg-icon-bg iconAnswer20Duotone native"></span>
+<span class="svg-icon-bg iconAnswer native"></span>
 ```
 
 For performance / file size reasons, not all icons are available in css. You can add support for more CSS icons my editing the `cssIcons` value in [config.yaml](config.yaml).
@@ -64,7 +64,7 @@ See the [dotnet/src/README.md](dotnet/src/README.md) file for more details.
 If you include the `browser.umd.js` within your prototype’s `body` element (`<script src="https://unpkg.com/@stackoverflow/stacks-icons/dist/browser.umd.js"></script>`) you can render Stacks Icons in the browser using only the following format:
 
 ```html
-<svg data-icon="IconAnswer20Duotone" class="native"></svg>
+<svg data-icon="IconAnswer" class="native"></svg>
 <svg data-spot="SpotSearch"></svg>
 ```
 
@@ -138,37 +138,41 @@ In order to expose a new icon to this repository, you'll need to convert it into
 
 #### Adding a published icon to this library
 
-In order to ensure that any new icons/spots in Figma are pulled into this repo, the definitions will need to be added to `config.yaml`:
+In order to ensure that any new icons/spots in Figma are pulled into this repo, the definitions will need to be added to `config.yaml`. The structure uses Figma component properties as keys with their corresponding hash values:
 
 ```yaml
 definitions:
     Icon/IconName:
-        20:
-            Duotone: ""
-            Fill: ""
-            Outline: ""
-        24:
-            Duotone: ""
-            Fill: ""
-            Outline: ""
-        32:
-            Duotone: ""
-            Fill: ""
-            Outline: ""
-        64:
-            Duotone: ""
-            Fill: ""
-            Outline: ""
+        Size=Default, Stack=False, Style=Default: ""
+        Size=Default, Stack=False, Style=Fill: ""
+        Size=Default, Stack=True, Style=Default: ""
+        Size=Default, Stack=True, Style=Fill: ""
 ```
 
-When adding new entries, please ensure that _all entries are in alphabetical order_ for ease of reference. Icons can have multiple sizes (`20`, `24`, `32`, `64`) and variants (`Duotone`, `Fill`, `Outline`) as defined in the Figma component. The initial hash values can be left empty. Once you run the first build process, it'll throw an error like the following:
+Icons can have various property combinations depending on their Figma component definition. Common properties include:
+- `Size=Default` (standard property for most icons)
+- `Stack=True|False` (whether the icon has a stacked variant)
+- `Style=Default|Fill` (visual style variant)
+- `Direction=Up|Down|Left|Right|UpLeft|UpRight|DownLeft|DownRight` (for directional icons like Arrow, Chevron, Vote, Trend)
+- `Box=True|False` (for boxed variants, e.g., some Arrow icons)
+- `Type=Default|Comment|Document|Dashboard|Review` (for icons with type variants like Compose, Mod)
+- `Off=True|False` (for toggle states, e.g., Flag, Notification)
+- `Open=True|False` (for open/closed states, e.g., Mail)
+- `Service=CCPA|Facebook|GitHub|Google|Instagram|LinkedIn|Threads|X|YouTube` (for service-specific icons)
+
+**Important:** When adding new entries, ensure that:
+1. The property order matches Figma's component definition (usually Size, then Boolean properties, then Style)
+2. All entries are in alphabetical order for ease of reference
+3. The initial hash values can be left empty (`""`)
+
+Once you run the first build process, it'll throw an error like the following:
 
 > ERROR Hash mismatch on 1 files. Expected hash values:
-> "Icon/Answer20Duotone": "AM0aL4NcirBVfs9hgLaJ2/zdQ3iwVc8poVQU/CFlu3g=",
+> "Icon/Answer": { "Size=Default, Stack=False, Style=Default": "UhYGuawhIoWxhzQLOu2XCwpBCK8a7p381CWsz/NYaDQ=" }
 
 Take these hash values and use them as the values for the previously added entries. Re-run the build process and verify that your new icon is added correctly and has the correct contents.
 
-When updating an existing icon, just update the corresponding hash value(s) for the size(s) and variant(s) that changed.
+When updating an existing icon, just update the corresponding hash value(s) for the property combination(s) that changed.
 
 ## Publishing a new release
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ definitions:
 ```
 
 Icons can have various property combinations depending on their Figma component definition. Common properties include:
+
 - `Size=Default` (standard property for most icons)
 - `Stack=True|False` (whether the icon has a stacked variant)
 - `Style=Default|Fill` (visual style variant)
@@ -161,6 +162,7 @@ Icons can have various property combinations depending on their Figma component 
 - `Service=CCPA|Facebook|GitHub|Google|Instagram|LinkedIn|Threads|X|YouTube` (for service-specific icons)
 
 **Important:** When adding new entries, ensure that:
+
 1. The property order matches Figma's component definition (usually Size, then Boolean properties, then Style)
 2. All entries are in alphabetical order for ease of reference
 3. The initial hash values can be left empty (`""`)

--- a/config.yaml
+++ b/config.yaml
@@ -66,8 +66,10 @@ definitions:
         Size=Default, Stack=True, Style=Default: ScQhDqNAhBwNuhRFlbpdf3YrWflcMpsr3Sl8Wd5hz2U=
         Size=Default, Stack=True, Style=Fill: jXLhAgkyY0nQYiwKScGPVXIkUyeO69tZDOhld8eE5ZE=
     Icon/Flag:
-        Size=Default, Style=Default: VfMyEb3mO3w3SeAp0sJ97ROSLN4daHfESvt0jfRS2ck=
-        Size=Default, Style=Fill: 0xduBLtkjETTAxpCLBgrOuEm9lVJjJDlRP2zPalr5iE=
+        Size=Default, Off=False, Style=Default: VfMyEb3mO3w3SeAp0sJ97ROSLN4daHfESvt0jfRS2ck=
+        Size=Default, Off=False, Style=Fill: 0xduBLtkjETTAxpCLBgrOuEm9lVJjJDlRP2zPalr5iE=
+        Size=Default, Off=True, Style=Default: KhQ6nQIar9Ho6tXFrWoSf32Zvv3kvxPQ4B/ikRcSq7g=
+        Size=Default, Off=True, Style=Fill: UHXQ1QaXsTRKytJtk1B2IG4yirGWbfCVZUQCvRnZ/8o=
     Icon/Help:
         Size=Default, Style=Default: 2U95Q8KwatUR6bk8cAiooB9waCqSs4e6ttWzS+GfkpM=
         Size=Default, Style=Fill: nBt2DDvfSoHjD1NJjJjMWRxfIku73N0gaQ11N7pEgss=
@@ -81,10 +83,10 @@ definitions:
         Size=Default, Style=Default: ixFJPBGrlypFsCfFb+kmRIR2A/97Py92Lk1/48MCpl4=
         Size=Default, Style=Fill: wUJcclwwXuaQny4EB94bVhjpgj7tsgjEuF6kPJtVaeo=
     Icon/Mail:
-        Size=Default, Style=Default, Open=False: WhcAd1fvjy8ToE6IZHmpVfzsg6dnL6LREPgv7rFRJRY=
-        Size=Default, Style=Default, Open=True: 9yaiPgJTnhAh3yAw8kD1uZF6bImqq/DF4opDR7xxE1g=
-        Size=Default, Style=Fill, Open=False: fvTjEXNozLXz3GaQfcCK+iFgBOO3aIMpBgsShXEFeaw=
-        Size=Default, Style=Fill, Open=True: 3ydoxQ5/H4cJOHdbw82VA+Obm+eUDulE2eoKMm7YP+k=
+        Size=Default, Open=False, Style=Default: WhcAd1fvjy8ToE6IZHmpVfzsg6dnL6LREPgv7rFRJRY=
+        Size=Default, Open=True, Style=Default: 9yaiPgJTnhAh3yAw8kD1uZF6bImqq/DF4opDR7xxE1g=
+        Size=Default, Open=False, Style=Fill: fvTjEXNozLXz3GaQfcCK+iFgBOO3aIMpBgsShXEFeaw=
+        Size=Default, Open=True, Style=Fill: 3ydoxQ5/H4cJOHdbw82VA+Obm+eUDulE2eoKMm7YP+k=
     Icon/Meta:
         Size=Default, Style=Default: aTSbEN8e0F7CiqBBXF31o6FVhi9mwLw4IqFIHejG6jQ=
         Size=Default, Style=Fill: kI6AKct33hBs3ARS42poi1Moio1Go4t9xAvDlAy8fX8=
@@ -98,10 +100,10 @@ definitions:
         Size=Default, Stack=True, Type=Review, Style=Default: w+VXthlcUkZ4u9Sm7sNqvSx8M3QSOWNWq18lm6XUSuc=
         Size=Default, Stack=True, Type=Review, Style=Fill: 7EJsTGm8ptZsCwnCiFiKl6uqPUeePdIXVIJfSLc3wjI=
     Icon/Notification:
-        Size=Default, Style=Default, Off=False: 73Eeld6BvW1KAunQqGvIXiskd3RSAxdpjfNXMVYnMVk=
-        Size=Default, Style=Default, Off=True: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=
-        Size=Default, Style=Fill, Off=False: PxcDANrg8BTkRxye4DjITVSy/sE03PLKZ1SOsEwuGFM=
-        Size=Default, Style=Fill, Off=True: FyYuve71a/2cQpmyEC66fjafZ3j1aNhn00Se1wTq63s=
+        Size=Default, Off=False, Style=Default: 73Eeld6BvW1KAunQqGvIXiskd3RSAxdpjfNXMVYnMVk=
+        Size=Default, Off=True, Style=Default: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=
+        Size=Default, Off=False, Style=Fill: PxcDANrg8BTkRxye4DjITVSy/sE03PLKZ1SOsEwuGFM=
+        Size=Default, Off=True, Style=Fill: FyYuve71a/2cQpmyEC66fjafZ3j1aNhn00Se1wTq63s=
     Icon/Plus:
         Size=Default, Style=Default: lw8/tZNKmMuQAe3F9I3XHD78DN3+flIhX2Hwc9TRzHQ=
     Icon/Question:

--- a/config.yaml
+++ b/config.yaml
@@ -106,6 +106,9 @@ definitions:
         Size=Default, Off=True, Style=Fill: FyYuve71a/2cQpmyEC66fjafZ3j1aNhn00Se1wTq63s=
     Icon/Plus:
         Size=Default, Style=Default: lw8/tZNKmMuQAe3F9I3XHD78DN3+flIhX2Hwc9TRzHQ=
+    Icon/QandA:
+        Size=Default, Style=Default: jytWoWKab4USAdof2e0XPju/eHGDZXB9BYqgTxYiYjU=
+        Size=Default, Style=Fill: IfacDbLJgpevPsrkB8QcBFMrXyhlGyeGjWxzPY+jBmU=
     Icon/Question:
         Size=Default, Stack=False, Style=Default: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
         Size=Default, Stack=False, Style=Fill: D3ZDd/OCRtsEZQmdvEr9M0Bsi5KiGfGU9QH3hjYNnaI=
@@ -118,10 +121,11 @@ definitions:
         Service=CCPA: Rdmbj7wOepT0DQ/Xt+/yT28321ua+Qmbe7Rl05fupbo=
         Service=Facebook: T1gYN/7ZA2ikxTLeqQQd7Bf08BwEQLJAHCt7phd5fbo=
         Service=GitHub: lePvVBW8ryn65VsQC0m2FE3K0S5+ZeFjRMt25gVJQ/w=
+        Service=Google: DEiGws6/awSIS5AYBSlttnUnuG2P5T5mvIUrfC9sHWI=
         Service=Instagram: 5iumIoct37WKO2RnXuAmjZL+0itOxXV9yE3SnmohBmk=
         Service=LinkedIn: 6U5pTyELv2eqPhWaKJ3WcOXWn/f5zqFQu0BbcnB4b4E=
         Service=Threads: emzQrEwRIX5dBGsGLypua0MigZOjWxvFWTPplkuBT80=
-        Service=X: fGISwtaROFU9RdbkrV4EKt/kXfGQpzCzlRruB27z9d4=
+        Service=X: 9VNZLtwu2CJT2O8WQMFKsrWm2Qw6t8ADv3cm+/uDym4=
         Service=YouTube: RlmgHwiijjX7uuwo0EziJDaCtCsVeWu8G66Pou2x/iE=
     Icon/Settings:
         Size=Default, Style=Default: aob4/1El7/PtbpvOxojM5mTlfi4V5auhGRCcloGDgtY=

--- a/config.yaml
+++ b/config.yaml
@@ -8,20 +8,16 @@ cssIcons:
 definitions:
     ### ICONS ###
     Icon/Answer:
-        Size=Default, Style=Default: Tka2S/Y2Ep2mZvRl1CXDktI8moCo6TfpnetwiK+EZdU=
-        Size=Default, Style=Fill: 3G3JqJfGbgDxdgWHFtEMkxjJdmGfI0Uton+UZAL5lvQ=
-    Icon/Answers:
-        Size=Default, Style=Default: ghkBC72aal00aaQZJ7YDA3woQEACFvlngFCnqk30yts=
-        Size=Default, Style=Fill: gUtZy5FfaTv2KIe8U1Tbecd50cSQ6o8qlIYZy9Y4T0U=
-    Icon/ArrowBottom:
-        Size=Default, Style=Default: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
-    Icon/ArrowLeft:
-        Size=Default, Style=Default: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
-    Icon/ArrowRight:
-        Size=Default, Style=Default: 7+7cORBbVMC4QAh8QQ7YuNjy9J53GQrJXL8/zNlO5bM=
-    Icon/ArrowUp:
-        Size=Default, Style=Default: PAEq06HrHwmRpjn2r/VRln2mRtqL28U+6IFfLC/DY88=
-    Icon/Awards:
+        Size=Default, Style=Default, Multiple=False: UhYGuawhIoWxhzQLOu2XCwpBCK8a7p381CWsz/NYaDQ=
+        Size=Default, Style=Default, Multiple=True: d4gX3H3Sj6dEjtafRAkzrV3FDIshS/FKs2RXdQm5v98=
+        Size=Default, Style=Fill, Multiple=False: ZSxm1d0ZixiMrUd53pIsNhbZI6tUJK0o+1T8VtGP8rQ=
+        Size=Default, Style=Fill, Multiple=True: gt10o2xtz6vsbE+Y/HfNU3BEnpVs/J+4EA9OAPHF//s=
+    Icon/Arrow:
+        Size=Default, Style=Default, Direction=Down: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
+        Size=Default, Style=Default, Direction=Left: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
+        Size=Default, Style=Default, Direction=Right: 7+7cORBbVMC4QAh8QQ7YuNjy9J53GQrJXL8/zNlO5bM=
+        Size=Default, Style=Default, Direction=Up: PAEq06HrHwmRpjn2r/VRln2mRtqL28U+6IFfLC/DY88=
+    Icon/Award:
         Size=Default, Style=Default: v+2A3J1etrBr9XTqNbQbn+I5/201OAwTRiJTTPAMQ3I=
         Size=Default, Style=Fill: 5pEjI4b1QSKOmDDEWqfu8YOTFH3FheCtaQttxbVVkJo=
     Icon/Bell:
@@ -36,28 +32,22 @@ definitions:
     Icon/Chat:
         Size=Default, Style=Default: UZmhVqgTlqIMTIvKybeETNDkiaep4fk3yffgDe1Z7EQ=
         Size=Default, Style=Fill: mykTtej4DI78wNP2RxJsqiRFaLprEK69nJJG5gBtEMk=
-    Icon/ChevronBottom:
-        Size=Default, Style=Default: hgC3wVuvo7pS8ireO0975RvQgDwPJ5uYj45sZoqLS+I=
-    Icon/ChevronLeft:
-        Size=Default, Style=Default: e+FK+EeAtZTY6wtZ5IS2WsUzeRq89lMZ5mFJulgzkI8=
-    Icon/ChevronRight:
-        Size=Default, Style=Default: RTcj+ktyxhGGhTzyodroDnya/aNOVbPebZTb2UnCjB4=
-    Icon/ChevronUp:
-        Size=Default, Style=Default: 6HSrg5trhBY70XhYLZyr1HCT+lOw7qsLzD4CbkqkZm4=
-    Icon/Communities:
+    Icon/Chevron:
+        Size=Default, Style=Default, Direction=Down: hgC3wVuvo7pS8ireO0975RvQgDwPJ5uYj45sZoqLS+I=
+        Size=Default, Style=Default, Direction=Left: e+FK+EeAtZTY6wtZ5IS2WsUzeRq89lMZ5mFJulgzkI8=
+        Size=Default, Style=Default, Direction=Right: RTcj+ktyxhGGhTzyodroDnya/aNOVbPebZTb2UnCjB4=
+        Size=Default, Style=Default, Direction=Up: 6HSrg5trhBY70XhYLZyr1HCT+lOw7qsLzD4CbkqkZm4=
+    Icon/Community:
         Size=Default, Style=Default: WYsmC7r1uaByLeE7Fe0M/JiaJ/J2kFx9wodtOuHcuaY=
         Size=Default, Style=Fill: 2fELsCJIS7B7KedTN12OZh0fRxP/HZTqeCKmgEDoV1Y=
-    Icon/Companies:
+    Icon/Company:
         Size=Default, Style=Default: F1u/wDLHPBlhJy+0OVOLEDlumvYjJJ2bqV24JPByMaQ=
         Size=Default, Style=Fill: GXotL9LfCMvihXA/cydC9B/kj0dTDaXxGwRZbYXkHuk=
     Icon/Cross:
-        Size=Default, Style=Default: ycef9Ez0L8HNf2DKMuCmVkjst+rv6c/76jKTd/nMdew=
+        Size=Default, Style=Default: oO1a2hCd/XuxAxpZXC+2EXJUAUWKpmv3AwCbkMBdUpQ=
     Icon/Document:
         Size=Default, Style=Default: G4FDvCrT7bv1T8tPFwSIAoiFn64SOcGYKxkZk6/cbIE=
         Size=Default, Style=Fill: tYmTyi2pC1roEjP6XO/qHm//CB7DlHtI1ssoK55G6pQ=
-    Icon/Downvote:
-        Size=Default, Style=Default: 2fzieA4oRep+Mat9+m9r+0xt9j7N7eObUXxC/JWWZEA=
-        Size=Default, Style=Fill: JDB6uLbbq62FIWvOO4kYneQFfzp0MD/B4fVbDi0WeVw=
     Icon/Flag:
         Size=Default, Style=Default: VfMyEb3mO3w3SeAp0sJ97ROSLN4daHfESvt0jfRS2ck=
         Size=Default, Style=Fill: 0xduBLtkjETTAxpCLBgrOuEm9lVJjJDlRP2zPalr5iE=
@@ -77,16 +67,15 @@ definitions:
         Size=Default, Style=Default: aTSbEN8e0F7CiqBBXF31o6FVhi9mwLw4IqFIHejG6jQ=
         Size=Default, Style=Fill: kI6AKct33hBs3ARS42poi1Moio1Go4t9xAvDlAy8fX8=
     Icon/Moderator:
-        Size=Default, Style=Default: 1hktkzNJPw7bDnhHzNf78FSwySD+ZJaGzMdZ6AqTMhs=
-        Size=Default, Style=Fill: c769+y8j2WkjlnTsDSC8yhvLmioTQRV1vs+DLjmFSfA=
+        Size=Default, Style=Default: RtVP3xGnTfC6Nidv0Kns6KmC24OEHOUgDunT5MjbyUM=
+        Size=Default, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
     Icon/Plus:
         Size=Default, Style=Default: LcnWxFYBuwca1rFC5YzROiVmtTVIBPxXfi73PLxoTp0=
     Icon/Question:
-        Size=Default, Style=Default: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
-        Size=Default, Style=Fill: MxkrhSkfEU3t2XD9BUGRPwY9SRntZh3AyGUPEEmvAys=
-    Icon/Questions:
-        Size=Default, Style=Default: rNkLDYVuqUVw/T1Ki1z9C3Rk5ww9LOKyiFMuirednHg=
-        Size=Default, Style=Fill: SRqL3BBwI4quz/wNah8BvVditzcxAmxzkqjA/+W+Tm0=
+        Size=Default, Style=Default, Multiple=False: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
+        Size=Default, Style=Default, Multiple=True: WTXl6gJ3T+ywl7y/5Pg57ifioeLBhVRydbTW+SnUyxw=
+        Size=Default, Style=Fill, Multiple=False: MxkrhSkfEU3t2XD9BUGRPwY9SRntZh3AyGUPEEmvAys=
+        Size=Default, Style=Fill, Multiple=True: SRqL3BBwI4quz/wNah8BvVditzcxAmxzkqjA/+W+Tm0=
     Icon/Search:
         Size=Default, Style=Default: 5tiLt2lGLoDXt/SzUCrvY364PCMpnGWJocLMS4fTvV4=
         Size=Default, Style=Fill: duJJyHlojXunPqpJTroKthlZBk8UwofChzM1QMUzCU4=
@@ -94,21 +83,23 @@ definitions:
         Size=Default, Style=Default: hXy6zBrXAilwe7PsNqFKPDaag94SCcWhapIiQVLxCQQ=
         Size=Default, Style=Fill: Tfi98jkq7WrjXlqTtPgYaSiXPXJ1VwXzvXpGuU2GWjM=
     Icon/Tag:
-        Size=Default, Style=Default: T1klaa7Zj1zxk797T2n0RafV3ukYhe7+Cn1xSv2HrjQ=
-        Size=Default, Style=Fill: z/MxNQ3RNBYOHnfxDb5dZI8FEoLxKbVskW+nkjdiF6Y=
-    Icon/Tags:
-        Size=Default, Style=Default: sbXMzg3JFcnAliwj2hdi4sLXe6Jq8iiPAXk0SuaIkpc=
-        Size=Default, Style=Fill: QCAsIE79DiZ++SeFcgIS3rM7nSa8J0kk+M3LWJHVck4=
-    Icon/TrendDown:
-        Size=Default, Style=Default: daagT7L/UF794p+C2+B/X6LTypAggeTatsb85r6mgXA=
-    Icon/TrendUp:
-        Size=Default, Style=Default: eM1sIQVpOBwgxp4zjh7x6uaMEENho5o3T6mMQqL7/cA=
-    Icon/Upvote:
-        Size=Default, Style=Default: B1kMREGxvjd2HO7xOH9u1rxGzxZsly5jlETcDU93tHs=
-        Size=Default, Style=Fill: dbuluBxCsqn3keaKcPzuea9e+UO5ETFwPvLlSmJw9Gg=
-    Icon/Users:
-        Size=Default, Style=Default: QBy3YTRKyYWHRW4tH1Koi5HSb5mjtGDWTBGd4fz4EoU=
-        Size=Default, Style=Fill: POtFlcnQ4rgUU13x/M+2EcDkNF+s6Ikte6akpXrnUGo=
+        Size=Default, Style=Default, Multiple=False: T1klaa7Zj1zxk797T2n0RafV3ukYhe7+Cn1xSv2HrjQ=
+        Size=Default, Style=Fill, Multiple=False: z/MxNQ3RNBYOHnfxDb5dZI8FEoLxKbVskW+nkjdiF6Y=
+        Size=Default, Style=Default, Multiple=True: f2A++4TNcT5Q+gu+++yVqfgTQrWZe68TGDCb1C8dNwc=
+        Size=Default, Style=Fill, Multiple=True: 1FG5l+DlJbDUzYVFwjboijl1nQ2tAWh/JVL259Z9a+U=
+    Icon/Trend:
+        Size=Default, Style=Default, Direction=Down: daagT7L/UF794p+C2+B/X6LTypAggeTatsb85r6mgXA=
+        Size=Default, Style=Default, Direction=Up: eM1sIQVpOBwgxp4zjh7x6uaMEENho5o3T6mMQqL7/cA=
+    Icon/User:
+        Size=Default, Style=Default, Multiple=False: WPgFC7g+cZmTOW/3GY818hRdXDXbzvBUofCt33ZOPpI=
+        Size=Default, Style=Default, Multiple=True: p+qDm8bRgfhZyP+A0C4Dqei/Yk6UhXnXfy14Igza0M8=
+        Size=Default, Style=Fill, Multiple=False: D4hdwZDRpdVaomKZSOs77Pkh411K6KcXoUlPKLI77gc=
+        Size=Default, Style=Fill, Multiple=True: 7e3obtp30vjZIrDFw6KtcJSt0bg5pVQvJAlr5lypv3c=
+    Icon/Vote:
+        Size=Default, Direction=Down, Style=Default: 9CQL3/zOyLED5v92OSAAni27V02+KhfoNNR/BwHSmiM=
+        Size=Default, Direction=Up, Style=Default: B1kMREGxvjd2HO7xOH9u1rxGzxZsly5jlETcDU93tHs=
+        Size=Default, Direction=Down, Style=Fill: JDB6uLbbq62FIWvOO4kYneQFfzp0MD/B4fVbDi0WeVw=
+        Size=Default, Direction=Up, Style=Fill: dbuluBxCsqn3keaKcPzuea9e+UO5ETFwPvLlSmJw9Gg=
     ### SPOTS ###
     Spot/Test: cgbl8iMviW3pIYnKyf1+vyH7e1gsGMlwxzIdPCfD5os=
     # TODO: add more spots here

--- a/config.yaml
+++ b/config.yaml
@@ -14,13 +14,13 @@ definitions:
         Size=Default, Style=Default: Z4Aqp4Tzor/yh2lJ3keipoSjzjyUgoxlUyYzotHeiSs=
 
     Icon/Document:
-        Size=Default, Style=Default: "7Pb1TvYRzbV2wqtFSrQIw0aqGFh7QstFaeuHBf3DQZk="
+        Size=Default, Style=Default: 7Pb1TvYRzbV2wqtFSrQIw0aqGFh7QstFaeuHBf3DQZk=
 
     Icon/Downvote:
         Size=Default, Style=Default: /OfUswkQOjHqmT/tPFbJxXrvkHwXk1M+WzSIV0LtwqU=
 
     Icon/Home:
-        Size=Default, Style=Default: "55XLf0sI9KjeXEceqbdqwSOYWoR7KpMPfP47mCzBNdI="
+        Size=Default, Style=Default: 55XLf0sI9KjeXEceqbdqwSOYWoR7KpMPfP47mCzBNdI=
 
     Icon/Question:
         Size=Default, Style=Default: k5BlX0M0jZTz0UJif35AM5ZQAo7jtHVHSOI7b/zw2jM=
@@ -38,7 +38,7 @@ definitions:
         Size=Default, Style=Default: CQWVcxmsphMOjeEXJymcT7jR5X03aeCZxS29pI9pJbA=
 
     ### SPOTS ###
-    Spot/Test: "cgbl8iMviW3pIYnKyf1+vyH7e1gsGMlwxzIdPCfD5os="
+    Spot/Test: cgbl8iMviW3pIYnKyf1+vyH7e1gsGMlwxzIdPCfD5os=
     # TODO: add more spots here
 
 ### CSS ICONS ###

--- a/config.yaml
+++ b/config.yaml
@@ -14,18 +14,18 @@ definitions:
         Size=Default, Stack=True, Style=Default: iJBgdNTZjmG49U+Wai/591GQbI9unytcKBcyc3hI7gg=
         Size=Default, Stack=True, Style=Fill: R2fVfpRcAiIAZWVhIY22OVevHSdLbjr/kKDzWq1duHQ=
     Icon/Arrow:
-        Size=Default, Box=False, Direction=DownLeft, Style=Default: Tim44ufb1/R6EuC/jv2kC1nJppewpnp0kqb3f8vhZaA=
-        Size=Default, Box=False, Direction=DownRight, Style=Default: CxKLfYzpZ24TjtfMbAsaCQqymMQOfcRa5oE/3/BmWW0=
-        Size=Default, Box=False, Direction=UpLeft, Style=Default: 3OvarnGEy2Bsg4XFW8Kpm9a5u8rODHM8YDmPAxBcMnM=
-        Size=Default, Box=False, Direction=UpRight, Style=Default: KkZ3wmKvAxzvGIjFEo36cm/9iLCEH8sxSyaZvnUL0u0=
-        Size=Default, Box=True, Direction=DownLeft, Style=Default: TUHeYu2AyVIeMGpZekMp3LfBYjR3jUCuSp1hwowCU9Y=
-        Size=Default, Box=True, Direction=Left, Style=Default: eKluR4dvjmTrhrcZMYNOpwqHP8aO0SLWm4YrTUUB1F0=
-        Size=Default, Box=True, Direction=Right, Style=Default: ZBva9TsDnHDyY2MupnQpr6HwVKrUjnlbTq7h75F1zNA=
-        Size=Default, Box=True, Direction=UpRight, Style=Default: bivAAqku4yOPMOtQQO2RFqKGX4R/ZyeWEay7xuCk64Y=
-        Size=Default, Style=Default, Direction=Down: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
-        Size=Default, Style=Default, Direction=Left: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
-        Size=Default, Style=Default, Direction=Right: o1PANqxMKtPQVT4JgPQT+Xmh5dOCOLRLeHzBBVPKos0=
-        Size=Default, Style=Default, Direction=Up: PAEq06HrHwmRpjn2r/VRln2mRtqL28U+6IFfLC/DY88=
+        Size=Default, Direction=DownLeft, Box=False, Style=Default: Tim44ufb1/R6EuC/jv2kC1nJppewpnp0kqb3f8vhZaA=
+        Size=Default, Direction=DownRight, Box=False, Style=Default: CxKLfYzpZ24TjtfMbAsaCQqymMQOfcRa5oE/3/BmWW0=
+        Size=Default, Direction=UpLeft, Box=False, Style=Default: 3OvarnGEy2Bsg4XFW8Kpm9a5u8rODHM8YDmPAxBcMnM=
+        Size=Default, Direction=UpRight, Box=False, Style=Default: KkZ3wmKvAxzvGIjFEo36cm/9iLCEH8sxSyaZvnUL0u0=
+        Size=Default, Direction=DownLeft, Box=True, Style=Default: TUHeYu2AyVIeMGpZekMp3LfBYjR3jUCuSp1hwowCU9Y=
+        Size=Default, Direction=Left, Box=True, Style=Default: eKluR4dvjmTrhrcZMYNOpwqHP8aO0SLWm4YrTUUB1F0=
+        Size=Default, Direction=Right, Box=True, Style=Default: ZBva9TsDnHDyY2MupnQpr6HwVKrUjnlbTq7h75F1zNA=
+        Size=Default, Direction=UpRight, Box=True, Style=Default: bivAAqku4yOPMOtQQO2RFqKGX4R/ZyeWEay7xuCk64Y=
+        Size=Default, Direction=Down, Style=Default: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
+        Size=Default, Direction=Left, Style=Default: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
+        Size=Default, Direction=Right, Style=Default: o1PANqxMKtPQVT4JgPQT+Xmh5dOCOLRLeHzBBVPKos0=
+        Size=Default, Direction=Up, Style=Default: PAEq06HrHwmRpjn2r/VRln2mRtqL28U+6IFfLC/DY88=
     Icon/Award:
         Size=Default, Style=Default: v+2A3J1etrBr9XTqNbQbn+I5/201OAwTRiJTTPAMQ3I=
         Size=Default, Style=Fill: X/UgKSKbmm84gueHG+Wny3Be3VAsT3UWkTwJsYg0BVw=
@@ -91,14 +91,14 @@ definitions:
         Size=Default, Style=Default: aTSbEN8e0F7CiqBBXF31o6FVhi9mwLw4IqFIHejG6jQ=
         Size=Default, Style=Fill: kI6AKct33hBs3ARS42poi1Moio1Go4t9xAvDlAy8fX8=
     Icon/Mod:
-        Size=Default, Stack=False, Type=Dashboard, Style=Default: lie1yOeXyQufTW7Dp2+566Oio6ewO+grg8rZX7GPeIc=
-        Size=Default, Stack=False, Type=Dashboard, Style=Fill: F0USYKs6fWU7fWueg47zbq4WfTQk0w2YIh7YyGNGobU=
-        Size=Default, Stack=False, Type=Default, Style=Default: TCCdy4xLkntnYPyQ7vYN/m+FjY3R0LUDS+gL/bbXDsc=
-        Size=Default, Stack=False, Type=Default, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
-        Size=Default, Stack=True, Type=Default, Style=Default: mqKD3dIepZ++JUhRGLFvXvtt9mIjdDBTIM1y7ueoy9g=
-        Size=Default, Stack=True, Type=Default, Style=Fill: cKDxmI60wYhDu4Wx5x4Y8Fn/iBodkUnbyip8JalI/Qs=
-        Size=Default, Stack=True, Type=Review, Style=Default: w+VXthlcUkZ4u9Sm7sNqvSx8M3QSOWNWq18lm6XUSuc=
-        Size=Default, Stack=True, Type=Review, Style=Fill: 7EJsTGm8ptZsCwnCiFiKl6uqPUeePdIXVIJfSLc3wjI=
+        Size=Default, Type=Dashboard, Stack=False, Style=Default: lie1yOeXyQufTW7Dp2+566Oio6ewO+grg8rZX7GPeIc=
+        Size=Default, Type=Dashboard, Stack=False, Style=Fill: F0USYKs6fWU7fWueg47zbq4WfTQk0w2YIh7YyGNGobU=
+        Size=Default, Type=Default, Stack=False, Style=Default: TCCdy4xLkntnYPyQ7vYN/m+FjY3R0LUDS+gL/bbXDsc=
+        Size=Default, Type=Default, Stack=False, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
+        Size=Default, Type=Default, Stack=True, Style=Default: mqKD3dIepZ++JUhRGLFvXvtt9mIjdDBTIM1y7ueoy9g=
+        Size=Default, Type=Default, Stack=True, Style=Fill: cKDxmI60wYhDu4Wx5x4Y8Fn/iBodkUnbyip8JalI/Qs=
+        Size=Default, Type=Review, Stack=True, Style=Default: w+VXthlcUkZ4u9Sm7sNqvSx8M3QSOWNWq18lm6XUSuc=
+        Size=Default, Type=Review, Stack=True, Style=Fill: 7EJsTGm8ptZsCwnCiFiKl6uqPUeePdIXVIJfSLc3wjI=
     Icon/Notification:
         Size=Default, Off=False, Style=Default: 73Eeld6BvW1KAunQqGvIXiskd3RSAxdpjfNXMVYnMVk=
         Size=Default, Off=True, Style=Default: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-### CSS ICONS ###
+# MARK: CSS Icons
 cssIcons:
     Answer:
         css: |
@@ -6,12 +6,13 @@ cssIcons:
             height: 20px;
         # TODO: add more icons to be added to the css bundle here
 definitions:
-    ### ICONS ###
+    # MARK: Icons
+    # Ensure order here and from Figma is Size=Default, Boolean=[True|False], Style=Default
     Icon/Answer:
-        Size=Default, Style=Default, Multiple=False: UhYGuawhIoWxhzQLOu2XCwpBCK8a7p381CWsz/NYaDQ=
-        Size=Default, Style=Default, Multiple=True: d4gX3H3Sj6dEjtafRAkzrV3FDIshS/FKs2RXdQm5v98=
-        Size=Default, Style=Fill, Multiple=False: ZSxm1d0ZixiMrUd53pIsNhbZI6tUJK0o+1T8VtGP8rQ=
-        Size=Default, Style=Fill, Multiple=True: gt10o2xtz6vsbE+Y/HfNU3BEnpVs/J+4EA9OAPHF//s=
+        Size=Default, Stack=False, Style=Default: UhYGuawhIoWxhzQLOu2XCwpBCK8a7p381CWsz/NYaDQ=
+        Size=Default, Stack=False, Style=Fill: ZSxm1d0ZixiMrUd53pIsNhbZI6tUJK0o+1T8VtGP8rQ=
+        Size=Default, Stack=True, Style=Default: d4gX3H3Sj6dEjtafRAkzrV3FDIshS/FKs2RXdQm5v98=
+        Size=Default, Stack=True, Style=Fill: gt10o2xtz6vsbE+Y/HfNU3BEnpVs/J+4EA9OAPHF//s=
     Icon/Arrow:
         Size=Default, Style=Default, Direction=Down: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
         Size=Default, Style=Default, Direction=Left: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
@@ -33,10 +34,10 @@ definitions:
         Size=Default, Style=Default: UZmhVqgTlqIMTIvKybeETNDkiaep4fk3yffgDe1Z7EQ=
         Size=Default, Style=Fill: mykTtej4DI78wNP2RxJsqiRFaLprEK69nJJG5gBtEMk=
     Icon/Chevron:
-        Size=Default, Style=Default, Direction=Down: hgC3wVuvo7pS8ireO0975RvQgDwPJ5uYj45sZoqLS+I=
-        Size=Default, Style=Default, Direction=Left: e+FK+EeAtZTY6wtZ5IS2WsUzeRq89lMZ5mFJulgzkI8=
-        Size=Default, Style=Default, Direction=Right: RTcj+ktyxhGGhTzyodroDnya/aNOVbPebZTb2UnCjB4=
-        Size=Default, Style=Default, Direction=Up: 6HSrg5trhBY70XhYLZyr1HCT+lOw7qsLzD4CbkqkZm4=
+        Size=Default, Direction=Down, Style=Default: hgC3wVuvo7pS8ireO0975RvQgDwPJ5uYj45sZoqLS+I=
+        Size=Default, Direction=Left, Style=Default: e+FK+EeAtZTY6wtZ5IS2WsUzeRq89lMZ5mFJulgzkI8=
+        Size=Default, Direction=Right, Style=Default: RTcj+ktyxhGGhTzyodroDnya/aNOVbPebZTb2UnCjB4=
+        Size=Default, Direction=Up, Style=Default: 6HSrg5trhBY70XhYLZyr1HCT+lOw7qsLzD4CbkqkZm4=
     Icon/Community:
         Size=Default, Style=Default: WYsmC7r1uaByLeE7Fe0M/JiaJ/J2kFx9wodtOuHcuaY=
         Size=Default, Style=Fill: 2fELsCJIS7B7KedTN12OZh0fRxP/HZTqeCKmgEDoV1Y=
@@ -72,10 +73,10 @@ definitions:
     Icon/Plus:
         Size=Default, Style=Default: LcnWxFYBuwca1rFC5YzROiVmtTVIBPxXfi73PLxoTp0=
     Icon/Question:
-        Size=Default, Style=Default, Multiple=False: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
-        Size=Default, Style=Default, Multiple=True: WTXl6gJ3T+ywl7y/5Pg57ifioeLBhVRydbTW+SnUyxw=
-        Size=Default, Style=Fill, Multiple=False: MxkrhSkfEU3t2XD9BUGRPwY9SRntZh3AyGUPEEmvAys=
-        Size=Default, Style=Fill, Multiple=True: SRqL3BBwI4quz/wNah8BvVditzcxAmxzkqjA/+W+Tm0=
+        Size=Default, Stack=False, Style=Default: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
+        Size=Default, Stack=False, Style=Fill: MxkrhSkfEU3t2XD9BUGRPwY9SRntZh3AyGUPEEmvAys=
+        Size=Default, Stack=True, Style=Default: WTXl6gJ3T+ywl7y/5Pg57ifioeLBhVRydbTW+SnUyxw=
+        Size=Default, Stack=True, Style=Fill: SRqL3BBwI4quz/wNah8BvVditzcxAmxzkqjA/+W+Tm0=
     Icon/Search:
         Size=Default, Style=Default: 5tiLt2lGLoDXt/SzUCrvY364PCMpnGWJocLMS4fTvV4=
         Size=Default, Style=Fill: duJJyHlojXunPqpJTroKthlZBk8UwofChzM1QMUzCU4=
@@ -83,23 +84,23 @@ definitions:
         Size=Default, Style=Default: hXy6zBrXAilwe7PsNqFKPDaag94SCcWhapIiQVLxCQQ=
         Size=Default, Style=Fill: Tfi98jkq7WrjXlqTtPgYaSiXPXJ1VwXzvXpGuU2GWjM=
     Icon/Tag:
-        Size=Default, Style=Default, Multiple=False: T1klaa7Zj1zxk797T2n0RafV3ukYhe7+Cn1xSv2HrjQ=
-        Size=Default, Style=Fill, Multiple=False: z/MxNQ3RNBYOHnfxDb5dZI8FEoLxKbVskW+nkjdiF6Y=
-        Size=Default, Style=Default, Multiple=True: f2A++4TNcT5Q+gu+++yVqfgTQrWZe68TGDCb1C8dNwc=
-        Size=Default, Style=Fill, Multiple=True: 1FG5l+DlJbDUzYVFwjboijl1nQ2tAWh/JVL259Z9a+U=
+        Size=Default, Stack=False, Style=Default: T1klaa7Zj1zxk797T2n0RafV3ukYhe7+Cn1xSv2HrjQ=
+        Size=Default, Stack=False, Style=Fill: z/MxNQ3RNBYOHnfxDb5dZI8FEoLxKbVskW+nkjdiF6Y=
+        Size=Default, Stack=True, Style=Default: f2A++4TNcT5Q+gu+++yVqfgTQrWZe68TGDCb1C8dNwc=
+        Size=Default, Stack=True, Style=Fill: 1FG5l+DlJbDUzYVFwjboijl1nQ2tAWh/JVL259Z9a+U=
     Icon/Trend:
-        Size=Default, Style=Default, Direction=Down: daagT7L/UF794p+C2+B/X6LTypAggeTatsb85r6mgXA=
-        Size=Default, Style=Default, Direction=Up: eM1sIQVpOBwgxp4zjh7x6uaMEENho5o3T6mMQqL7/cA=
+        Size=Default, Direction=Down, Style=Default: daagT7L/UF794p+C2+B/X6LTypAggeTatsb85r6mgXA=
+        Size=Default, Direction=Up, Style=Default: eM1sIQVpOBwgxp4zjh7x6uaMEENho5o3T6mMQqL7/cA=
     Icon/User:
-        Size=Default, Style=Default, Multiple=False: WPgFC7g+cZmTOW/3GY818hRdXDXbzvBUofCt33ZOPpI=
-        Size=Default, Style=Default, Multiple=True: p+qDm8bRgfhZyP+A0C4Dqei/Yk6UhXnXfy14Igza0M8=
-        Size=Default, Style=Fill, Multiple=False: D4hdwZDRpdVaomKZSOs77Pkh411K6KcXoUlPKLI77gc=
-        Size=Default, Style=Fill, Multiple=True: 7e3obtp30vjZIrDFw6KtcJSt0bg5pVQvJAlr5lypv3c=
+        Size=Default, Stack=False: WPgFC7g+cZmTOW/3GY818hRdXDXbzvBUofCt33ZOPpI=
+        Size=Default, Stack=False, Style=Fill: D4hdwZDRpdVaomKZSOs77Pkh411K6KcXoUlPKLI77gc=
+        Size=Default, Stack=True, Style=Default: p+qDm8bRgfhZyP+A0C4Dqei/Yk6UhXnXfy14Igza0M8=
+        Size=Default, Stack=True, Style=Fill: 7e3obtp30vjZIrDFw6KtcJSt0bg5pVQvJAlr5lypv3c=
     Icon/Vote:
         Size=Default, Direction=Down, Style=Default: 9CQL3/zOyLED5v92OSAAni27V02+KhfoNNR/BwHSmiM=
-        Size=Default, Direction=Up, Style=Default: B1kMREGxvjd2HO7xOH9u1rxGzxZsly5jlETcDU93tHs=
         Size=Default, Direction=Down, Style=Fill: JDB6uLbbq62FIWvOO4kYneQFfzp0MD/B4fVbDi0WeVw=
+        Size=Default, Direction=Up, Style=Default: B1kMREGxvjd2HO7xOH9u1rxGzxZsly5jlETcDU93tHs=
         Size=Default, Direction=Up, Style=Fill: dbuluBxCsqn3keaKcPzuea9e+UO5ETFwPvLlSmJw9Gg=
-    ### SPOTS ###
+    # MARK: Spots
     Spot/Test: cgbl8iMviW3pIYnKyf1+vyH7e1gsGMlwxzIdPCfD5os=
     # TODO: add more spots here

--- a/config.yaml
+++ b/config.yaml
@@ -52,14 +52,14 @@ definitions:
         Size=Default, Style=Default: q1wqop1+hqnlgaLsto6EabsKfLe1v3iI9Tr5Lsu79Qk=
         Size=Default, Style=Fill: IDpo47bEbh8aNy2Mau10xc4NJTfwaFe6QswYSMSWfyw=
     Icon/Compose:
+        Size=Default, Type=Comment, Style=Default: dzaowkPNkLgUDxR/MU4+TNlQO1lBlpYFRbRudiXqHUA=
+        Size=Default, Type=Comment, Style=Fill: 9oRZCJb2sHO5Hv0am6UtfMqo6ZcLgpadLntBRXLDh+Q=
         Size=Default, Type=Default, Style=Default: x5UYSQi6ml7GVC+rC5FLpNEE3ICD2DkK+30J6D//WIE=
         Size=Default, Type=Default, Style=Fill: lMuWBTnMtSg3KXpI7UmOQEvzS6IZmOfcgFCGTGSFYNk=
         Size=Default, Type=Document, Style=Default: TQ7S8NbtbH33/z5Q1jhUywYHxdgqk0HCtc2V4Tocv0s=
-        Size=Default, Type=Document, Style=Fill: X13xkEgeOMBmV6Zn/iBKEQwZnNCkEU5JGTxdKFhZfIQ=
-        Size=Icon, Type=Comment, Style=Comment: dzaowkPNkLgUDxR/MU4+TNlQO1lBlpYFRbRudiXqHUA=
-        Size=Icon, Type=Comment, Style=Fill: xwj6SdIpBmC3xOLgA8kT/49cNywlxfynUqFfdeHzmSY=
+        Size=Default, Type=Document, Style=Fill: RRl5y4Ko0Vg/KHP+Hbiaay6dbNUyT72sCRR+1+H8XUg=
     Icon/Cross:
-        Size=Default, Style=Default: H0obNJmpJhcTmLaVQwQPWEwiQjrf6Al0ouHieUUfTP8=
+        Size=Default, Style=Default: uku27vCVvTj1PL6ThHT0WswCVFJloTT8Y4KYJlq7ENM=
     Icon/Document:
         Size=Default, Style=Default, Stacked=False: AIbPzwa31i5WJvdNhL2E39Ggjr60ROBYy9kws71CMSU=
         Size=Default, Style=Default, Stacked=True: ScQhDqNAhBwNuhRFlbpdf3YrWflcMpsr3Sl8Wd5hz2U=
@@ -95,15 +95,15 @@ definitions:
         Size=Default, Type=Default, Stack=False, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
         Size=Default, Type=Default, Stack=True, Style=Default: mqKD3dIepZ++JUhRGLFvXvtt9mIjdDBTIM1y7ueoy9g=
         Size=Default, Type=Default, Stack=True, Style=Fill: cKDxmI60wYhDu4Wx5x4Y8Fn/iBodkUnbyip8JalI/Qs=
-        Size=Default, Type=Review, Stack=True, Style=Default: ghQrdgC3GTPitGHhSYNwyguOVlsql1IGZMETbfJGVKM=
-        Size=Default, Type=Review, Stack=True, Style=Fill: 5BVaFm747cqMrKUDwGsSzxRnAWWSP9CJnaJrBwfOoPk=
+        Size=Default, Type=Review, Stack=True, Style=Default: w+VXthlcUkZ4u9Sm7sNqvSx8M3QSOWNWq18lm6XUSuc=
+        Size=Default, Type=Review, Stack=True, Style=Fill: 7EJsTGm8ptZsCwnCiFiKl6uqPUeePdIXVIJfSLc3wjI=
     Icon/Notification:
         Size=Default, Style=Default, Off=False: 73Eeld6BvW1KAunQqGvIXiskd3RSAxdpjfNXMVYnMVk=
         Size=Default, Style=Default, Off=True: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=
         Size=Default, Style=Fill, Off=False: PxcDANrg8BTkRxye4DjITVSy/sE03PLKZ1SOsEwuGFM=
         Size=Default, Style=Fill, Off=True: FyYuve71a/2cQpmyEC66fjafZ3j1aNhn00Se1wTq63s=
     Icon/Plus:
-        Size=Default, Style=Default: LcnWxFYBuwca1rFC5YzROiVmtTVIBPxXfi73PLxoTp0=
+        Size=Default, Style=Default: lw8/tZNKmMuQAe3F9I3XHD78DN3+flIhX2Hwc9TRzHQ=
     Icon/Question:
         Size=Default, Stack=False, Style=Default: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
         Size=Default, Stack=False, Style=Fill: D3ZDd/OCRtsEZQmdvEr9M0Bsi5KiGfGU9QH3hjYNnaI=

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ definitions:
     ### ICONS ###
     Icon/Answer:
         Size=Default, Style=Default: /IlrLWBhKHpOxW2OtCQFVcDuSgkbsRn+EUJrzmdrswA=
+        Size=32, Style=Fill: 4v6RqqVUNUjnTBnue8IohwCT3/PgiHx2BJ8Gghza2lg=
 
     Icon/Answers:
         Size=Default, Style=Default: M3lN8KicgTPhbYHPVSUcbbj0sj46E7Q44m76UGQXJmA=

--- a/config.yaml
+++ b/config.yaml
@@ -1,50 +1,114 @@
-definitions:
-    ### ICONS ###
-    Icon/Answer:
-        Size=Default, Style=Default: /IlrLWBhKHpOxW2OtCQFVcDuSgkbsRn+EUJrzmdrswA=
-        Size=32, Style=Fill: 4v6RqqVUNUjnTBnue8IohwCT3/PgiHx2BJ8Gghza2lg=
-
-    Icon/Answers:
-        Size=Default, Style=Default: M3lN8KicgTPhbYHPVSUcbbj0sj46E7Q44m76UGQXJmA=
-
-    Icon/Bookmark:
-        Size=Default, Style=Default: 4/0Vmtx64WKAzp9VWaSePPPjcsz+FSYiA59gAhmVJLA=
-
-    Icon/Chat:
-        Size=Default, Style=Default: Z4Aqp4Tzor/yh2lJ3keipoSjzjyUgoxlUyYzotHeiSs=
-
-    Icon/Document:
-        Size=Default, Style=Default: 7Pb1TvYRzbV2wqtFSrQIw0aqGFh7QstFaeuHBf3DQZk=
-
-    Icon/Downvote:
-        Size=Default, Style=Default: /OfUswkQOjHqmT/tPFbJxXrvkHwXk1M+WzSIV0LtwqU=
-
-    Icon/Home:
-        Size=Default, Style=Default: 55XLf0sI9KjeXEceqbdqwSOYWoR7KpMPfP47mCzBNdI=
-
-    Icon/Question:
-        Size=Default, Style=Default: k5BlX0M0jZTz0UJif35AM5ZQAo7jtHVHSOI7b/zw2jM=
-
-    Icon/Questions:
-        Size=Default, Style=Default: KfbXukyfZ/c+1TRkPdpCWm2ApNverRkb6gugb6BUgss=
-
-    Icon/Tag:
-        Size=Default, Style=Default: rvgD+Pg6trm1QUfJo0abYrx+2LUTtIfbugB9Tzurfg8=
-
-    Icon/Tags:
-        Size=Default, Style=Default: V7D24XI43t8n7rKKlg013n8xVXJBfJJUm0K2kGLfPps=
-
-    Icon/Upvote:
-        Size=Default, Style=Default: CQWVcxmsphMOjeEXJymcT7jR5X03aeCZxS29pI9pJbA=
-
-    ### SPOTS ###
-    Spot/Test: cgbl8iMviW3pIYnKyf1+vyH7e1gsGMlwxzIdPCfD5os=
-    # TODO: add more spots here
-
 ### CSS ICONS ###
 cssIcons:
     Answer:
         css: |
             width: 20px;
             height: 20px;
-    # TODO: add more icons to be added to the css bundle here
+        # TODO: add more icons to be added to the css bundle here
+definitions:
+    ### ICONS ###
+    Icon/Answer:
+        Size=Default, Style=Default: Tka2S/Y2Ep2mZvRl1CXDktI8moCo6TfpnetwiK+EZdU=
+        Size=Default, Style=Fill: 3G3JqJfGbgDxdgWHFtEMkxjJdmGfI0Uton+UZAL5lvQ=
+    Icon/Answers:
+        Size=Default, Style=Default: ghkBC72aal00aaQZJ7YDA3woQEACFvlngFCnqk30yts=
+        Size=Default, Style=Fill: gUtZy5FfaTv2KIe8U1Tbecd50cSQ6o8qlIYZy9Y4T0U=
+    Icon/ArrowBottom:
+        Size=Default, Style=Default: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
+    Icon/ArrowLeft:
+        Size=Default, Style=Default: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
+    Icon/ArrowRight:
+        Size=Default, Style=Default: 7+7cORBbVMC4QAh8QQ7YuNjy9J53GQrJXL8/zNlO5bM=
+    Icon/ArrowUp:
+        Size=Default, Style=Default: PAEq06HrHwmRpjn2r/VRln2mRtqL28U+6IFfLC/DY88=
+    Icon/Awards:
+        Size=Default, Style=Default: v+2A3J1etrBr9XTqNbQbn+I5/201OAwTRiJTTPAMQ3I=
+        Size=Default, Style=Fill: 5pEjI4b1QSKOmDDEWqfu8YOTFH3FheCtaQttxbVVkJo=
+    Icon/Bell:
+        Size=Default, Style=Default: r09v7rhoycyL/NvCOSeIJFl/0rwc2mzJvbKpv8ZJXFM=
+        Size=Default, Style=Fill: ZYWRbdnFjhhfPfhG4HOD/CUWKLLN6zrS1aJvX4sqDcc=
+    Icon/Bookmark:
+        Size=Default, Style=Default: +AXI3/LDPgztq/O1tlzxPbewDJLC5e+AkHY0r5a50hs=
+        Size=Default, Style=Fill: SoilsBkrXfPids6Tnfbl5fNPCBVU/SzX6ZOol1ti54U=
+    Icon/Challenge:
+        Size=Default, Style=Default: kG3FDOFEQDLmVvnwRmrTf1pYmwOy2FYfdnbEUIP7id0=
+        Size=Default, Style=Fill: GageAeDddJSbouE06Xk2hHhrCMX5BwKmDUR7jxTJkkY=
+    Icon/Chat:
+        Size=Default, Style=Default: UZmhVqgTlqIMTIvKybeETNDkiaep4fk3yffgDe1Z7EQ=
+        Size=Default, Style=Fill: mykTtej4DI78wNP2RxJsqiRFaLprEK69nJJG5gBtEMk=
+    Icon/ChevronBottom:
+        Size=Default, Style=Default: hgC3wVuvo7pS8ireO0975RvQgDwPJ5uYj45sZoqLS+I=
+    Icon/ChevronLeft:
+        Size=Default, Style=Default: e+FK+EeAtZTY6wtZ5IS2WsUzeRq89lMZ5mFJulgzkI8=
+    Icon/ChevronRight:
+        Size=Default, Style=Default: RTcj+ktyxhGGhTzyodroDnya/aNOVbPebZTb2UnCjB4=
+    Icon/ChevronUp:
+        Size=Default, Style=Default: 6HSrg5trhBY70XhYLZyr1HCT+lOw7qsLzD4CbkqkZm4=
+    Icon/Communities:
+        Size=Default, Style=Default: WYsmC7r1uaByLeE7Fe0M/JiaJ/J2kFx9wodtOuHcuaY=
+        Size=Default, Style=Fill: 2fELsCJIS7B7KedTN12OZh0fRxP/HZTqeCKmgEDoV1Y=
+    Icon/Companies:
+        Size=Default, Style=Default: F1u/wDLHPBlhJy+0OVOLEDlumvYjJJ2bqV24JPByMaQ=
+        Size=Default, Style=Fill: GXotL9LfCMvihXA/cydC9B/kj0dTDaXxGwRZbYXkHuk=
+    Icon/Cross:
+        Size=Default, Style=Default: ycef9Ez0L8HNf2DKMuCmVkjst+rv6c/76jKTd/nMdew=
+    Icon/Document:
+        Size=Default, Style=Default: G4FDvCrT7bv1T8tPFwSIAoiFn64SOcGYKxkZk6/cbIE=
+        Size=Default, Style=Fill: tYmTyi2pC1roEjP6XO/qHm//CB7DlHtI1ssoK55G6pQ=
+    Icon/Downvote:
+        Size=Default, Style=Default: 2fzieA4oRep+Mat9+m9r+0xt9j7N7eObUXxC/JWWZEA=
+        Size=Default, Style=Fill: JDB6uLbbq62FIWvOO4kYneQFfzp0MD/B4fVbDi0WeVw=
+    Icon/Flag:
+        Size=Default, Style=Default: VfMyEb3mO3w3SeAp0sJ97ROSLN4daHfESvt0jfRS2ck=
+        Size=Default, Style=Fill: 0xduBLtkjETTAxpCLBgrOuEm9lVJjJDlRP2zPalr5iE=
+    Icon/Help:
+        Size=Default, Style=Default: 2U95Q8KwatUR6bk8cAiooB9waCqSs4e6ttWzS+GfkpM=
+        Size=Default, Style=Fill: nBt2DDvfSoHjD1NJjJjMWRxfIku73N0gaQ11N7pEgss=
+    Icon/Home:
+        Size=Default, Style=Default: PoAKhksimke9mURtwprpur5c1Pdg3DX/JSoQkhpAZoo=
+        Size=Default, Style=Fill: Gppd5eUt1tuEUnIbxhRISj+Dh0E3av0J0egRmnfy/yw=
+    Icon/Inbox:
+        Size=Default, Style=Default: qBx3mL4ty0hIzkEpSaFqrQK9ase5DcjmNg1xOGuPl1M=
+        Size=Default, Style=Fill: nEh51bcWsYKvmXcWfvqTGll7UOwJdyDqKjSwKT8XO2I=
+    Icon/Jobs:
+        Size=Default, Style=Default: ixFJPBGrlypFsCfFb+kmRIR2A/97Py92Lk1/48MCpl4=
+        Size=Default, Style=Fill: 56taEheo4mFgkqo0s3fiEo6dGycjNWybjoYuMjfoxOM=
+    Icon/Meta:
+        Size=Default, Style=Default: aTSbEN8e0F7CiqBBXF31o6FVhi9mwLw4IqFIHejG6jQ=
+        Size=Default, Style=Fill: kI6AKct33hBs3ARS42poi1Moio1Go4t9xAvDlAy8fX8=
+    Icon/Moderator:
+        Size=Default, Style=Default: 1hktkzNJPw7bDnhHzNf78FSwySD+ZJaGzMdZ6AqTMhs=
+        Size=Default, Style=Fill: c769+y8j2WkjlnTsDSC8yhvLmioTQRV1vs+DLjmFSfA=
+    Icon/Plus:
+        Size=Default, Style=Default: LcnWxFYBuwca1rFC5YzROiVmtTVIBPxXfi73PLxoTp0=
+    Icon/Question:
+        Size=Default, Style=Default: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
+        Size=Default, Style=Fill: MxkrhSkfEU3t2XD9BUGRPwY9SRntZh3AyGUPEEmvAys=
+    Icon/Questions:
+        Size=Default, Style=Default: rNkLDYVuqUVw/T1Ki1z9C3Rk5ww9LOKyiFMuirednHg=
+        Size=Default, Style=Fill: SRqL3BBwI4quz/wNah8BvVditzcxAmxzkqjA/+W+Tm0=
+    Icon/Search:
+        Size=Default, Style=Default: 5tiLt2lGLoDXt/SzUCrvY364PCMpnGWJocLMS4fTvV4=
+        Size=Default, Style=Fill: duJJyHlojXunPqpJTroKthlZBk8UwofChzM1QMUzCU4=
+    Icon/Settings:
+        Size=Default, Style=Default: hXy6zBrXAilwe7PsNqFKPDaag94SCcWhapIiQVLxCQQ=
+        Size=Default, Style=Fill: Tfi98jkq7WrjXlqTtPgYaSiXPXJ1VwXzvXpGuU2GWjM=
+    Icon/Tag:
+        Size=Default, Style=Default: T1klaa7Zj1zxk797T2n0RafV3ukYhe7+Cn1xSv2HrjQ=
+        Size=Default, Style=Fill: z/MxNQ3RNBYOHnfxDb5dZI8FEoLxKbVskW+nkjdiF6Y=
+    Icon/Tags:
+        Size=Default, Style=Default: sbXMzg3JFcnAliwj2hdi4sLXe6Jq8iiPAXk0SuaIkpc=
+        Size=Default, Style=Fill: QCAsIE79DiZ++SeFcgIS3rM7nSa8J0kk+M3LWJHVck4=
+    Icon/TrendDown:
+        Size=Default, Style=Default: daagT7L/UF794p+C2+B/X6LTypAggeTatsb85r6mgXA=
+    Icon/TrendUp:
+        Size=Default, Style=Default: eM1sIQVpOBwgxp4zjh7x6uaMEENho5o3T6mMQqL7/cA=
+    Icon/Upvote:
+        Size=Default, Style=Default: B1kMREGxvjd2HO7xOH9u1rxGzxZsly5jlETcDU93tHs=
+        Size=Default, Style=Fill: dbuluBxCsqn3keaKcPzuea9e+UO5ETFwPvLlSmJw9Gg=
+    Icon/Users:
+        Size=Default, Style=Default: QBy3YTRKyYWHRW4tH1Koi5HSb5mjtGDWTBGd4fz4EoU=
+        Size=Default, Style=Fill: POtFlcnQ4rgUU13x/M+2EcDkNF+s6Ikte6akpXrnUGo=
+    ### SPOTS ###
+    Spot/Test: cgbl8iMviW3pIYnKyf1+vyH7e1gsGMlwxzIdPCfD5os=
+    # TODO: add more spots here

--- a/config.yaml
+++ b/config.yaml
@@ -10,28 +10,35 @@ definitions:
     # Ensure order here and from Figma is Size=Default, Boolean=[True|False], Style=Default
     Icon/Answer:
         Size=Default, Stack=False, Style=Default: UhYGuawhIoWxhzQLOu2XCwpBCK8a7p381CWsz/NYaDQ=
-        Size=Default, Stack=False, Style=Fill: ZSxm1d0ZixiMrUd53pIsNhbZI6tUJK0o+1T8VtGP8rQ=
-        Size=Default, Stack=True, Style=Default: d4gX3H3Sj6dEjtafRAkzrV3FDIshS/FKs2RXdQm5v98=
-        Size=Default, Stack=True, Style=Fill: gt10o2xtz6vsbE+Y/HfNU3BEnpVs/J+4EA9OAPHF//s=
+        Size=Default, Stack=False, Style=Fill: 4SxmO+xwNb0RwVK1mYmODjbKIEG/5aI5SMT05KZbmck=
+        Size=Default, Stack=True, Style=Default: iJBgdNTZjmG49U+Wai/591GQbI9unytcKBcyc3hI7gg=
+        Size=Default, Stack=True, Style=Fill: R2fVfpRcAiIAZWVhIY22OVevHSdLbjr/kKDzWq1duHQ=
     Icon/Arrow:
+        Size=Default, Box=False, Direction=DownLeft, Style=Default: Tim44ufb1/R6EuC/jv2kC1nJppewpnp0kqb3f8vhZaA=
+        Size=Default, Box=False, Direction=DownRight, Style=Default: CxKLfYzpZ24TjtfMbAsaCQqymMQOfcRa5oE/3/BmWW0=
+        Size=Default, Box=False, Direction=UpLeft, Style=Default: 3OvarnGEy2Bsg4XFW8Kpm9a5u8rODHM8YDmPAxBcMnM=
+        Size=Default, Box=False, Direction=UpRight, Style=Default: KkZ3wmKvAxzvGIjFEo36cm/9iLCEH8sxSyaZvnUL0u0=
+        Size=Default, Box=True, Direction=DownLeft, Style=Default: TUHeYu2AyVIeMGpZekMp3LfBYjR3jUCuSp1hwowCU9Y=
+        Size=Default, Box=True, Direction=Left, Style=Default: eKluR4dvjmTrhrcZMYNOpwqHP8aO0SLWm4YrTUUB1F0=
+        Size=Default, Box=True, Direction=Right, Style=Default: ZBva9TsDnHDyY2MupnQpr6HwVKrUjnlbTq7h75F1zNA=
+        Size=Default, Box=True, Direction=UpRight, Style=Default: bivAAqku4yOPMOtQQO2RFqKGX4R/ZyeWEay7xuCk64Y=
         Size=Default, Style=Default, Direction=Down: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
         Size=Default, Style=Default, Direction=Left: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
-        Size=Default, Style=Default, Direction=Right: 7+7cORBbVMC4QAh8QQ7YuNjy9J53GQrJXL8/zNlO5bM=
+        Size=Default, Style=Default, Direction=Right: o1PANqxMKtPQVT4JgPQT+Xmh5dOCOLRLeHzBBVPKos0=
         Size=Default, Style=Default, Direction=Up: PAEq06HrHwmRpjn2r/VRln2mRtqL28U+6IFfLC/DY88=
     Icon/Award:
         Size=Default, Style=Default: v+2A3J1etrBr9XTqNbQbn+I5/201OAwTRiJTTPAMQ3I=
-        Size=Default, Style=Fill: 5pEjI4b1QSKOmDDEWqfu8YOTFH3FheCtaQttxbVVkJo=
-    Icon/Bell:
-        Size=Default, Style=Default: r09v7rhoycyL/NvCOSeIJFl/0rwc2mzJvbKpv8ZJXFM=
-        Size=Default, Style=Fill: ZYWRbdnFjhhfPfhG4HOD/CUWKLLN6zrS1aJvX4sqDcc=
+        Size=Default, Style=Fill: X/UgKSKbmm84gueHG+Wny3Be3VAsT3UWkTwJsYg0BVw=
     Icon/Bookmark:
-        Size=Default, Style=Default: +AXI3/LDPgztq/O1tlzxPbewDJLC5e+AkHY0r5a50hs=
-        Size=Default, Style=Fill: SoilsBkrXfPids6Tnfbl5fNPCBVU/SzX6ZOol1ti54U=
+        Size=Default, Stack=False, Style=Default: pPAQtUNbfWM5TSQud3wOqBTU4if65RWO66UpE0/1tRI=
+        Size=Default, Stack=False, Style=Fill: 4ezFi+gqEM5bIxT9+TUzkI3FZDVV5RhPut9KF03Jdq4=
+        Size=Default, Stack=True, Style=Default: VMQv5qRC1BVe0MHZ9GF5G9JO2WSMlHuwQWdYNUBUrWA=
+        Size=Default, Stack=True, Style=Fill: vuPawxigVYjJtYZtYIuf4zWr35vzrZylj+Wlp6P/E2c=
     Icon/Challenge:
         Size=Default, Style=Default: kG3FDOFEQDLmVvnwRmrTf1pYmwOy2FYfdnbEUIP7id0=
         Size=Default, Style=Fill: GageAeDddJSbouE06Xk2hHhrCMX5BwKmDUR7jxTJkkY=
     Icon/Chat:
-        Size=Default, Style=Default: UZmhVqgTlqIMTIvKybeETNDkiaep4fk3yffgDe1Z7EQ=
+        Size=Default, Style=Default: VZeGXLbI41AkFC/NFlIljNQBtPP4dsCNa5gVz2yu0Zw=
         Size=Default, Style=Fill: mykTtej4DI78wNP2RxJsqiRFaLprEK69nJJG5gBtEMk=
     Icon/Chevron:
         Size=Default, Direction=Down, Style=Default: hgC3wVuvo7pS8ireO0975RvQgDwPJ5uYj45sZoqLS+I=
@@ -39,16 +46,25 @@ definitions:
         Size=Default, Direction=Right, Style=Default: RTcj+ktyxhGGhTzyodroDnya/aNOVbPebZTb2UnCjB4=
         Size=Default, Direction=Up, Style=Default: 6HSrg5trhBY70XhYLZyr1HCT+lOw7qsLzD4CbkqkZm4=
     Icon/Community:
-        Size=Default, Style=Default: WYsmC7r1uaByLeE7Fe0M/JiaJ/J2kFx9wodtOuHcuaY=
-        Size=Default, Style=Fill: 2fELsCJIS7B7KedTN12OZh0fRxP/HZTqeCKmgEDoV1Y=
+        Size=Default, Style=Default: qdcrUSCQn0MVM5fKVvLWGH1FnPlszJ0pcj9is1UfHy8=
+        Size=Default, Style=Fill: bFqAq08t76cCit336mS2U3bvCmpyUjlDN35k+jLvFFY=
     Icon/Company:
-        Size=Default, Style=Default: F1u/wDLHPBlhJy+0OVOLEDlumvYjJJ2bqV24JPByMaQ=
-        Size=Default, Style=Fill: GXotL9LfCMvihXA/cydC9B/kj0dTDaXxGwRZbYXkHuk=
+        Size=Default, Style=Default: q1wqop1+hqnlgaLsto6EabsKfLe1v3iI9Tr5Lsu79Qk=
+        Size=Default, Style=Fill: IDpo47bEbh8aNy2Mau10xc4NJTfwaFe6QswYSMSWfyw=
+    Icon/Compose:
+        Size=Default, Type=Default, Style=Default: x5UYSQi6ml7GVC+rC5FLpNEE3ICD2DkK+30J6D//WIE=
+        Size=Default, Type=Default, Style=Fill: lMuWBTnMtSg3KXpI7UmOQEvzS6IZmOfcgFCGTGSFYNk=
+        Size=Default, Type=Document, Style=Default: TQ7S8NbtbH33/z5Q1jhUywYHxdgqk0HCtc2V4Tocv0s=
+        Size=Default, Type=Document, Style=Fill: X13xkEgeOMBmV6Zn/iBKEQwZnNCkEU5JGTxdKFhZfIQ=
+        Size=Icon, Type=Comment, Style=Comment: dzaowkPNkLgUDxR/MU4+TNlQO1lBlpYFRbRudiXqHUA=
+        Size=Icon, Type=Comment, Style=Fill: xwj6SdIpBmC3xOLgA8kT/49cNywlxfynUqFfdeHzmSY=
     Icon/Cross:
-        Size=Default, Style=Default: oO1a2hCd/XuxAxpZXC+2EXJUAUWKpmv3AwCbkMBdUpQ=
+        Size=Default, Style=Default: H0obNJmpJhcTmLaVQwQPWEwiQjrf6Al0ouHieUUfTP8=
     Icon/Document:
-        Size=Default, Style=Default: G4FDvCrT7bv1T8tPFwSIAoiFn64SOcGYKxkZk6/cbIE=
-        Size=Default, Style=Fill: tYmTyi2pC1roEjP6XO/qHm//CB7DlHtI1ssoK55G6pQ=
+        Size=Default, Style=Default, Stacked=False: AIbPzwa31i5WJvdNhL2E39Ggjr60ROBYy9kws71CMSU=
+        Size=Default, Style=Default, Stacked=True: ScQhDqNAhBwNuhRFlbpdf3YrWflcMpsr3Sl8Wd5hz2U=
+        Size=Default, Style=Fill, Stacked=False: 52u0TZ4/BxAFi2DC1xpmd1e7IrWLxqlrGznDVaWG1GY=
+        Size=Default, Style=Fill, Stacked=True: jXLhAgkyY0nQYiwKScGPVXIkUyeO69tZDOhld8eE5ZE=
     Icon/Flag:
         Size=Default, Style=Default: VfMyEb3mO3w3SeAp0sJ97ROSLN4daHfESvt0jfRS2ck=
         Size=Default, Style=Fill: 0xduBLtkjETTAxpCLBgrOuEm9lVJjJDlRP2zPalr5iE=
@@ -57,35 +73,60 @@ definitions:
         Size=Default, Style=Fill: nBt2DDvfSoHjD1NJjJjMWRxfIku73N0gaQ11N7pEgss=
     Icon/Home:
         Size=Default, Style=Default: PoAKhksimke9mURtwprpur5c1Pdg3DX/JSoQkhpAZoo=
-        Size=Default, Style=Fill: Gppd5eUt1tuEUnIbxhRISj+Dh0E3av0J0egRmnfy/yw=
+        Size=Default, Style=Fill: TO4C4SFGu3c8LlQoI8vb7aXjdyzXB7vybpHilm8fpo4=
     Icon/Inbox:
-        Size=Default, Style=Default: qBx3mL4ty0hIzkEpSaFqrQK9ase5DcjmNg1xOGuPl1M=
-        Size=Default, Style=Fill: nEh51bcWsYKvmXcWfvqTGll7UOwJdyDqKjSwKT8XO2I=
+        Size=Default, Style=Default: OwT0V4gYYLd/Ok5MaA+XCMgVx/4uFQVji3KANO2Q7dM=
+        Size=Default, Style=Fill: HMc4gMSj0WpsydIY4i33bOnih9BSlKJsndICzIIgmmA=
     Icon/Jobs:
         Size=Default, Style=Default: ixFJPBGrlypFsCfFb+kmRIR2A/97Py92Lk1/48MCpl4=
-        Size=Default, Style=Fill: 56taEheo4mFgkqo0s3fiEo6dGycjNWybjoYuMjfoxOM=
+        Size=Default, Style=Fill: wUJcclwwXuaQny4EB94bVhjpgj7tsgjEuF6kPJtVaeo=
+    Icon/Mail:
+        Size=Default, Style=Default, Open=False: WhcAd1fvjy8ToE6IZHmpVfzsg6dnL6LREPgv7rFRJRY=
+        Size=Default, Style=Default, Open=True: 9yaiPgJTnhAh3yAw8kD1uZF6bImqq/DF4opDR7xxE1g=
+        Size=Default, Style=Fill, Open=False: fvTjEXNozLXz3GaQfcCK+iFgBOO3aIMpBgsShXEFeaw=
+        Size=Default, Style=Fill, Open=True: 3ydoxQ5/H4cJOHdbw82VA+Obm+eUDulE2eoKMm7YP+k=
     Icon/Meta:
         Size=Default, Style=Default: aTSbEN8e0F7CiqBBXF31o6FVhi9mwLw4IqFIHejG6jQ=
         Size=Default, Style=Fill: kI6AKct33hBs3ARS42poi1Moio1Go4t9xAvDlAy8fX8=
-    Icon/Moderator:
-        Size=Default, Style=Default: RtVP3xGnTfC6Nidv0Kns6KmC24OEHOUgDunT5MjbyUM=
-        Size=Default, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
+    Icon/Mod:
+        Size=Default, Type=Dashboard, Stack=False, Style=Default: lie1yOeXyQufTW7Dp2+566Oio6ewO+grg8rZX7GPeIc=
+        Size=Default, Type=Dashboard, Stack=False, Style=Fill: F0USYKs6fWU7fWueg47zbq4WfTQk0w2YIh7YyGNGobU=
+        Size=Default, Type=Default, Stack=False, Style=Default: TCCdy4xLkntnYPyQ7vYN/m+FjY3R0LUDS+gL/bbXDsc=
+        Size=Default, Type=Default, Stack=False, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
+        Size=Default, Type=Default, Stack=True, Style=Default: mqKD3dIepZ++JUhRGLFvXvtt9mIjdDBTIM1y7ueoy9g=
+        Size=Default, Type=Default, Stack=True, Style=Fill: cKDxmI60wYhDu4Wx5x4Y8Fn/iBodkUnbyip8JalI/Qs=
+        Size=Default, Type=Review, Stack=True, Style=Default: ghQrdgC3GTPitGHhSYNwyguOVlsql1IGZMETbfJGVKM=
+        Size=Default, Type=Review, Stack=True, Style=Fill: 5BVaFm747cqMrKUDwGsSzxRnAWWSP9CJnaJrBwfOoPk=
+    Icon/Notification:
+        Size=Default, Style=Default, Off=False: 73Eeld6BvW1KAunQqGvIXiskd3RSAxdpjfNXMVYnMVk=
+        Size=Default, Style=Default, Off=True: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=
+        Size=Default, Style=Fill, Off=False: PxcDANrg8BTkRxye4DjITVSy/sE03PLKZ1SOsEwuGFM=
+        Size=Default, Style=Fill, Off=True: FyYuve71a/2cQpmyEC66fjafZ3j1aNhn00Se1wTq63s=
     Icon/Plus:
         Size=Default, Style=Default: LcnWxFYBuwca1rFC5YzROiVmtTVIBPxXfi73PLxoTp0=
     Icon/Question:
         Size=Default, Stack=False, Style=Default: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
-        Size=Default, Stack=False, Style=Fill: MxkrhSkfEU3t2XD9BUGRPwY9SRntZh3AyGUPEEmvAys=
-        Size=Default, Stack=True, Style=Default: WTXl6gJ3T+ywl7y/5Pg57ifioeLBhVRydbTW+SnUyxw=
-        Size=Default, Stack=True, Style=Fill: SRqL3BBwI4quz/wNah8BvVditzcxAmxzkqjA/+W+Tm0=
+        Size=Default, Stack=False, Style=Fill: D3ZDd/OCRtsEZQmdvEr9M0Bsi5KiGfGU9QH3hjYNnaI=
+        Size=Default, Stack=True, Style=Default: muKvkHoBhrGXTu8ym75UfRegrwmZh1Z2SV+jcNK+K/s=
+        Size=Default, Stack=True, Style=Fill: hPyKgQcgf29CFmNqIMVd24RV//HFuz1YYgnzzAI0d1w=
     Icon/Search:
         Size=Default, Style=Default: 5tiLt2lGLoDXt/SzUCrvY364PCMpnGWJocLMS4fTvV4=
         Size=Default, Style=Fill: duJJyHlojXunPqpJTroKthlZBk8UwofChzM1QMUzCU4=
+    Icon/Service:
+        Service=CCPA: Rdmbj7wOepT0DQ/Xt+/yT28321ua+Qmbe7Rl05fupbo=
+        Service=Facebook: T1gYN/7ZA2ikxTLeqQQd7Bf08BwEQLJAHCt7phd5fbo=
+        Service=GitHub: lePvVBW8ryn65VsQC0m2FE3K0S5+ZeFjRMt25gVJQ/w=
+        Service=Instagram: 5iumIoct37WKO2RnXuAmjZL+0itOxXV9yE3SnmohBmk=
+        Service=LinkedIn: 6U5pTyELv2eqPhWaKJ3WcOXWn/f5zqFQu0BbcnB4b4E=
+        Service=Threads: emzQrEwRIX5dBGsGLypua0MigZOjWxvFWTPplkuBT80=
+        Service=X: fGISwtaROFU9RdbkrV4EKt/kXfGQpzCzlRruB27z9d4=
+        Service=YouTube: RlmgHwiijjX7uuwo0EziJDaCtCsVeWu8G66Pou2x/iE=
     Icon/Settings:
-        Size=Default, Style=Default: hXy6zBrXAilwe7PsNqFKPDaag94SCcWhapIiQVLxCQQ=
-        Size=Default, Style=Fill: Tfi98jkq7WrjXlqTtPgYaSiXPXJ1VwXzvXpGuU2GWjM=
+        Size=Default, Style=Default: aob4/1El7/PtbpvOxojM5mTlfi4V5auhGRCcloGDgtY=
+        Size=Default, Style=Fill: 1SfkVGkvMeW+TjtfsBQD3mbzz7HdOhxdTcm4n2z2vDY=
     Icon/Tag:
         Size=Default, Stack=False, Style=Default: T1klaa7Zj1zxk797T2n0RafV3ukYhe7+Cn1xSv2HrjQ=
-        Size=Default, Stack=False, Style=Fill: z/MxNQ3RNBYOHnfxDb5dZI8FEoLxKbVskW+nkjdiF6Y=
+        Size=Default, Stack=False, Style=Fill: a/pOL2qxTgzcDczIgBMIxwuN5nfrmOEp9BjXzyrtxDg=
         Size=Default, Stack=True, Style=Default: f2A++4TNcT5Q+gu+++yVqfgTQrWZe68TGDCb1C8dNwc=
         Size=Default, Stack=True, Style=Fill: 1FG5l+DlJbDUzYVFwjboijl1nQ2tAWh/JVL259Z9a+U=
     Icon/Trend:
@@ -93,8 +134,8 @@ definitions:
         Size=Default, Direction=Up, Style=Default: eM1sIQVpOBwgxp4zjh7x6uaMEENho5o3T6mMQqL7/cA=
     Icon/User:
         Size=Default, Stack=False: WPgFC7g+cZmTOW/3GY818hRdXDXbzvBUofCt33ZOPpI=
-        Size=Default, Stack=False, Style=Fill: D4hdwZDRpdVaomKZSOs77Pkh411K6KcXoUlPKLI77gc=
-        Size=Default, Stack=True, Style=Default: p+qDm8bRgfhZyP+A0C4Dqei/Yk6UhXnXfy14Igza0M8=
+        Size=Default, Stack=False, Style=Fill: VudgYGOUTfVe/oAkL2bkC8zQmTKk2K8kaMR4IxYMDcA=
+        Size=Default, Stack=True, Style=Default: CyLH/BejIIzTnPsh72ZnlVBLiBGq6C/6W0BJKVxrBfM=
         Size=Default, Stack=True, Style=Fill: 7e3obtp30vjZIrDFw6KtcJSt0bg5pVQvJAlr5lypv3c=
     Icon/Vote:
         Size=Default, Direction=Down, Style=Default: 9CQL3/zOyLED5v92OSAAni27V02+KhfoNNR/BwHSmiM=

--- a/config.yaml
+++ b/config.yaml
@@ -14,18 +14,18 @@ definitions:
         Size=Default, Stack=True, Style=Default: iJBgdNTZjmG49U+Wai/591GQbI9unytcKBcyc3hI7gg=
         Size=Default, Stack=True, Style=Fill: R2fVfpRcAiIAZWVhIY22OVevHSdLbjr/kKDzWq1duHQ=
     Icon/Arrow:
-        Size=Default, Direction=DownLeft, Box=False, Style=Default: Tim44ufb1/R6EuC/jv2kC1nJppewpnp0kqb3f8vhZaA=
-        Size=Default, Direction=DownRight, Box=False, Style=Default: CxKLfYzpZ24TjtfMbAsaCQqymMQOfcRa5oE/3/BmWW0=
-        Size=Default, Direction=UpLeft, Box=False, Style=Default: 3OvarnGEy2Bsg4XFW8Kpm9a5u8rODHM8YDmPAxBcMnM=
-        Size=Default, Direction=UpRight, Box=False, Style=Default: KkZ3wmKvAxzvGIjFEo36cm/9iLCEH8sxSyaZvnUL0u0=
-        Size=Default, Direction=DownLeft, Box=True, Style=Default: TUHeYu2AyVIeMGpZekMp3LfBYjR3jUCuSp1hwowCU9Y=
-        Size=Default, Direction=Left, Box=True, Style=Default: eKluR4dvjmTrhrcZMYNOpwqHP8aO0SLWm4YrTUUB1F0=
-        Size=Default, Direction=Right, Box=True, Style=Default: ZBva9TsDnHDyY2MupnQpr6HwVKrUjnlbTq7h75F1zNA=
-        Size=Default, Direction=UpRight, Box=True, Style=Default: bivAAqku4yOPMOtQQO2RFqKGX4R/ZyeWEay7xuCk64Y=
         Size=Default, Direction=Down, Style=Default: coXzVGYCBzkTNNaUWJH4NUVz4/DpTSAO+/BMOKqjytw=
+        Size=Default, Direction=DownLeft, Box=False, Style=Default: Tim44ufb1/R6EuC/jv2kC1nJppewpnp0kqb3f8vhZaA=
+        Size=Default, Direction=DownLeft, Box=True, Style=Default: TUHeYu2AyVIeMGpZekMp3LfBYjR3jUCuSp1hwowCU9Y=
+        Size=Default, Direction=DownRight, Box=False, Style=Default: CxKLfYzpZ24TjtfMbAsaCQqymMQOfcRa5oE/3/BmWW0=
+        Size=Default, Direction=Left, Box=True, Style=Default: eKluR4dvjmTrhrcZMYNOpwqHP8aO0SLWm4YrTUUB1F0=
         Size=Default, Direction=Left, Style=Default: lJ/dusbuhFzN7Cv/8CiQvjqMJ4i4baxkxYnRBo7Qbc0=
+        Size=Default, Direction=Right, Box=True, Style=Default: ZBva9TsDnHDyY2MupnQpr6HwVKrUjnlbTq7h75F1zNA=
         Size=Default, Direction=Right, Style=Default: o1PANqxMKtPQVT4JgPQT+Xmh5dOCOLRLeHzBBVPKos0=
         Size=Default, Direction=Up, Style=Default: PAEq06HrHwmRpjn2r/VRln2mRtqL28U+6IFfLC/DY88=
+        Size=Default, Direction=UpLeft, Box=False, Style=Default: 3OvarnGEy2Bsg4XFW8Kpm9a5u8rODHM8YDmPAxBcMnM=
+        Size=Default, Direction=UpRight, Box=False, Style=Default: KkZ3wmKvAxzvGIjFEo36cm/9iLCEH8sxSyaZvnUL0u0=
+        Size=Default, Direction=UpRight, Box=True, Style=Default: bivAAqku4yOPMOtQQO2RFqKGX4R/ZyeWEay7xuCk64Y=
     Icon/Award:
         Size=Default, Style=Default: v+2A3J1etrBr9XTqNbQbn+I5/201OAwTRiJTTPAMQ3I=
         Size=Default, Style=Fill: X/UgKSKbmm84gueHG+Wny3Be3VAsT3UWkTwJsYg0BVw=
@@ -84,8 +84,8 @@ definitions:
         Size=Default, Style=Fill: wUJcclwwXuaQny4EB94bVhjpgj7tsgjEuF6kPJtVaeo=
     Icon/Mail:
         Size=Default, Open=False, Style=Default: WhcAd1fvjy8ToE6IZHmpVfzsg6dnL6LREPgv7rFRJRY=
-        Size=Default, Open=True, Style=Default: 9yaiPgJTnhAh3yAw8kD1uZF6bImqq/DF4opDR7xxE1g=
         Size=Default, Open=False, Style=Fill: fvTjEXNozLXz3GaQfcCK+iFgBOO3aIMpBgsShXEFeaw=
+        Size=Default, Open=True, Style=Default: 9yaiPgJTnhAh3yAw8kD1uZF6bImqq/DF4opDR7xxE1g=
         Size=Default, Open=True, Style=Fill: 3ydoxQ5/H4cJOHdbw82VA+Obm+eUDulE2eoKMm7YP+k=
     Icon/Meta:
         Size=Default, Style=Default: aTSbEN8e0F7CiqBBXF31o6FVhi9mwLw4IqFIHejG6jQ=
@@ -101,8 +101,8 @@ definitions:
         Size=Default, Type=Review, Stack=True, Style=Fill: 7EJsTGm8ptZsCwnCiFiKl6uqPUeePdIXVIJfSLc3wjI=
     Icon/Notification:
         Size=Default, Off=False, Style=Default: 73Eeld6BvW1KAunQqGvIXiskd3RSAxdpjfNXMVYnMVk=
-        Size=Default, Off=True, Style=Default: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=
         Size=Default, Off=False, Style=Fill: PxcDANrg8BTkRxye4DjITVSy/sE03PLKZ1SOsEwuGFM=
+        Size=Default, Off=True, Style=Default: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=
         Size=Default, Off=True, Style=Fill: FyYuve71a/2cQpmyEC66fjafZ3j1aNhn00Se1wTq63s=
     Icon/Plus:
         Size=Default, Style=Default: lw8/tZNKmMuQAe3F9I3XHD78DN3+flIhX2Hwc9TRzHQ=

--- a/config.yaml
+++ b/config.yaml
@@ -61,10 +61,10 @@ definitions:
     Icon/Cross:
         Size=Default, Style=Default: uku27vCVvTj1PL6ThHT0WswCVFJloTT8Y4KYJlq7ENM=
     Icon/Document:
-        Size=Default, Style=Default, Stacked=False: AIbPzwa31i5WJvdNhL2E39Ggjr60ROBYy9kws71CMSU=
-        Size=Default, Style=Default, Stacked=True: ScQhDqNAhBwNuhRFlbpdf3YrWflcMpsr3Sl8Wd5hz2U=
-        Size=Default, Style=Fill, Stacked=False: 52u0TZ4/BxAFi2DC1xpmd1e7IrWLxqlrGznDVaWG1GY=
-        Size=Default, Style=Fill, Stacked=True: jXLhAgkyY0nQYiwKScGPVXIkUyeO69tZDOhld8eE5ZE=
+        Size=Default, Stack=False, Style=Default: AIbPzwa31i5WJvdNhL2E39Ggjr60ROBYy9kws71CMSU=
+        Size=Default, Stack=False, Style=Fill: 52u0TZ4/BxAFi2DC1xpmd1e7IrWLxqlrGznDVaWG1GY=
+        Size=Default, Stack=True, Style=Default: ScQhDqNAhBwNuhRFlbpdf3YrWflcMpsr3Sl8Wd5hz2U=
+        Size=Default, Stack=True, Style=Fill: jXLhAgkyY0nQYiwKScGPVXIkUyeO69tZDOhld8eE5ZE=
     Icon/Flag:
         Size=Default, Style=Default: VfMyEb3mO3w3SeAp0sJ97ROSLN4daHfESvt0jfRS2ck=
         Size=Default, Style=Fill: 0xduBLtkjETTAxpCLBgrOuEm9lVJjJDlRP2zPalr5iE=
@@ -89,14 +89,14 @@ definitions:
         Size=Default, Style=Default: aTSbEN8e0F7CiqBBXF31o6FVhi9mwLw4IqFIHejG6jQ=
         Size=Default, Style=Fill: kI6AKct33hBs3ARS42poi1Moio1Go4t9xAvDlAy8fX8=
     Icon/Mod:
-        Size=Default, Type=Dashboard, Stack=False, Style=Default: lie1yOeXyQufTW7Dp2+566Oio6ewO+grg8rZX7GPeIc=
-        Size=Default, Type=Dashboard, Stack=False, Style=Fill: F0USYKs6fWU7fWueg47zbq4WfTQk0w2YIh7YyGNGobU=
-        Size=Default, Type=Default, Stack=False, Style=Default: TCCdy4xLkntnYPyQ7vYN/m+FjY3R0LUDS+gL/bbXDsc=
-        Size=Default, Type=Default, Stack=False, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
-        Size=Default, Type=Default, Stack=True, Style=Default: mqKD3dIepZ++JUhRGLFvXvtt9mIjdDBTIM1y7ueoy9g=
-        Size=Default, Type=Default, Stack=True, Style=Fill: cKDxmI60wYhDu4Wx5x4Y8Fn/iBodkUnbyip8JalI/Qs=
-        Size=Default, Type=Review, Stack=True, Style=Default: w+VXthlcUkZ4u9Sm7sNqvSx8M3QSOWNWq18lm6XUSuc=
-        Size=Default, Type=Review, Stack=True, Style=Fill: 7EJsTGm8ptZsCwnCiFiKl6uqPUeePdIXVIJfSLc3wjI=
+        Size=Default, Stack=False, Type=Dashboard, Style=Default: lie1yOeXyQufTW7Dp2+566Oio6ewO+grg8rZX7GPeIc=
+        Size=Default, Stack=False, Type=Dashboard, Style=Fill: F0USYKs6fWU7fWueg47zbq4WfTQk0w2YIh7YyGNGobU=
+        Size=Default, Stack=False, Type=Default, Style=Default: TCCdy4xLkntnYPyQ7vYN/m+FjY3R0LUDS+gL/bbXDsc=
+        Size=Default, Stack=False, Type=Default, Style=Fill: OmPJ9H/nSSjaqAR1BPkixIvW+1FCrcYBA1oTbZiwhU8=
+        Size=Default, Stack=True, Type=Default, Style=Default: mqKD3dIepZ++JUhRGLFvXvtt9mIjdDBTIM1y7ueoy9g=
+        Size=Default, Stack=True, Type=Default, Style=Fill: cKDxmI60wYhDu4Wx5x4Y8Fn/iBodkUnbyip8JalI/Qs=
+        Size=Default, Stack=True, Type=Review, Style=Default: w+VXthlcUkZ4u9Sm7sNqvSx8M3QSOWNWq18lm6XUSuc=
+        Size=Default, Stack=True, Type=Review, Style=Fill: 7EJsTGm8ptZsCwnCiFiKl6uqPUeePdIXVIJfSLc3wjI=
     Icon/Notification:
         Size=Default, Style=Default, Off=False: 73Eeld6BvW1KAunQqGvIXiskd3RSAxdpjfNXMVYnMVk=
         Size=Default, Style=Default, Off=True: FBP4Iw0+8H5OzDj7m6Bax/8BpQHRoup5fKgkxfrZH1k=

--- a/config.yaml
+++ b/config.yaml
@@ -1,220 +1,40 @@
 definitions:
     ### ICONS ###
     Icon/Answer:
-        20:
-            Duotone: AM0aL4NcirBVfs9hgLaJ2/zdQ3iwVc8poVQU/CFlu3g=
-            Fill: 3G3JqJfGbgDxdgWHFtEMkxjJdmGfI0Uton+UZAL5lvQ=
-            Outline: Tka2S/Y2Ep2mZvRl1CXDktI8moCo6TfpnetwiK+EZdU=
-        24:
-            Duotone: NVZeOE+pZmlpk4Kqg9000Bx12jqubZ/OemO6G0SmV9s=
-            Fill: sBneAgahZ0JtbIW+b1r0XOZ2Wk68wjmfCN1uaEnz0nQ=
-            Outline: /IlrLWBhKHpOxW2OtCQFVcDuSgkbsRn+EUJrzmdrswA=
-        32:
-            Duotone: foiD6eG9WhxUnjvrYzI/NTxFyn+2E7+OsdpbxTc/fzI=
-            Fill: 4v6RqqVUNUjnTBnue8IohwCT3/PgiHx2BJ8Gghza2lg=
-            Outline: 1uz9szQFpT8fnkpKcvaNdo8kQmPDCxhovZFw45BpO6Q=
-        64:
-            Duotone: 31WFN4WJyg0vbX9XTY1PkFrJa70CKQWRr5A27MAIUKo=
-            Fill: i/woP6j7VKcDNh00FHK/9N/aMcCbtSXiFHWrlYZplx0=
-            Outline: ARuvUA6OsWTXMuayer1OgC+ZS9XKZgy5E492Fuh7JuI=
+        Size=Default, Style=Default: /IlrLWBhKHpOxW2OtCQFVcDuSgkbsRn+EUJrzmdrswA=
 
     Icon/Answers:
-        20:
-            Duotone: Sjf2fOvyyW1sj/CdbxtI9MehbfFNp7oONvkJzKqALKA=
-            Fill: gUtZy5FfaTv2KIe8U1Tbecd50cSQ6o8qlIYZy9Y4T0U=
-            Outline: ghkBC72aal00aaQZJ7YDA3woQEACFvlngFCnqk30yts=
-        24:
-            Duotone: Q+v4OaOKcy4BKD7cjwKlZZArCYLCesVtzlqiRmoGZPU=
-            Fill: E2Mwc+cndp4dljwZYp6p/CqMG5IpifltqCokpr4Xzpk=
-            Outline: M3lN8KicgTPhbYHPVSUcbbj0sj46E7Q44m76UGQXJmA=
-        32:
-            Duotone: tsO+roOLwOnasObKlD9WE8IpRJ9KkEkzIkWPrEu+SV8=
-            Fill: EWwX98n1cxTVB051sLB4UZR0v7MDTn+qO3RVhNTHAgE=
-            Outline: +d0T7ipGvnGm3OEYDbalVHs5+8flAL3sqv7uE3BSyME=
-        64:
-            Duotone: 6Aw6k3Y0W+Zwn0rRfGfY43gTo4RuaO6/sYFn6XJT75s=
-            Fill: t/OXL6TyummU46xGKof8Tam2nhOi6zEY8QzH5w5f7ts=
-            Outline: x5h/RcQYkcGpA+blBRcGPBPeGpBBzGjC4Tqb+ATxTKs=
+        Size=Default, Style=Default: M3lN8KicgTPhbYHPVSUcbbj0sj46E7Q44m76UGQXJmA=
 
     Icon/Bookmark:
-        20:
-            Duotone: 7htnZaFVOLEFec3/O9hzxYvbWtlC89bVOcb16kW6obw=
-            Fill: SoilsBkrXfPids6Tnfbl5fNPCBVU/SzX6ZOol1ti54U=
-            Outline: +AXI3/LDPgztq/O1tlzxPbewDJLC5e+AkHY0r5a50hs=
-        24:
-            Duotone: hpoEVxztik1spoPUdDp36dvA176gJD4yvprmg1eb4Mo=
-            Fill: Np1iIwSM10MXui1Kbne327zPpJ8ZkWJMHkoZVwy1pdM=
-            Outline: 4/0Vmtx64WKAzp9VWaSePPPjcsz+FSYiA59gAhmVJLA=
-        32:
-            Duotone: XykKZPkEiP+OnY8ihIA6EiFDEjfgThl9jMX/5vm6J1w=
-            Fill: 8GNSX0OVG/fPCl5QQFtBZxU0qkcr2hoGAcop9m5DB9Q=
-            Outline: n3cvReuZl91YH/urtQmsxq2MpAp3LC+TcyN9fRyDgeo=
-        64:
-            Duotone: l6uiXLpbouUm0+gfiAxgjqLlLN06nbQWIWEJsIZAwGM=
-            Fill: MfQOfhuvXSRf0dytf55rVppzBP/h+KIlTghNEJMzpm0=
-            Outline: Ovc4Rh5Rxyp2nMA1puMiQhLcIGiv1l9V+WltelCbbIw=
+        Size=Default, Style=Default: 4/0Vmtx64WKAzp9VWaSePPPjcsz+FSYiA59gAhmVJLA=
 
     Icon/Chat:
-        20:
-            Duotone: 17Tq/Br3Hbwu1BpI997wExTPsX0jjtEfoGv2fY09/j4=
-            Fill: mykTtej4DI78wNP2RxJsqiRFaLprEK69nJJG5gBtEMk=
-            Outline: VZeGXLbI41AkFC/NFlIljNQBtPP4dsCNa5gVz2yu0Zw=
-        24:
-            Duotone: /twTJJBOPj7Bnnq5UDoRqcJLK4DedvCXPStqWe8eaCE=
-            Fill: JWhyKoEFW86+Bsd3XetlhQnl/zhCNgantleVwaF9jvA=
-            Outline: Z4Aqp4Tzor/yh2lJ3keipoSjzjyUgoxlUyYzotHeiSs=
-        32:
-            Duotone: 6qySu0WknQrpqHEXELLbHSJlp8F+Bg+jK7W1jwp0X90=
-            Fill: 6jymH1WIlYTX84N0e0DRAwB0LdJGpWONfddj2iJU9h0=
-            Outline: EJlA8+Uno5LgvpzMjuas8bECOdKFjfewUcGl0jSHlnM=
-        64:
-            Duotone: pXaGVNh07tEGdV8bB8WEuHpQ3Kd+gV79lfQCxas8+Ew=
-            Fill: IALEY2NWEPc81lF3yvPCHTcEpI9k1PHcyKF6yMRa2D8=
-            Outline: GbOgeBXSHBfhkRYqhdhMj3JtjRkDyOJitBul7WoUVTo=
+        Size=Default, Style=Default: Z4Aqp4Tzor/yh2lJ3keipoSjzjyUgoxlUyYzotHeiSs=
 
     Icon/Document:
-        20:
-            Duotone: "ZDkny5pAaf3s6uAuvtW0xTcGTRMFt0qHusqY+j6Kdhc="
-            Fill: "tYmTyi2pC1roEjP6XO/qHm//CB7DlHtI1ssoK55G6pQ="
-            Outline: "GIPPJZVRMCi7LHbHcjq48sTK8T8jvEi1Tu2LytNuCEk="
-        24:
-            Duotone: "sqCOw2/jRsgthCC0BF6OJ5ocQMon1PfCn5onSi1lPec="
-            Fill: "sqCOw2/jRsgthCC0BF6OJ5ocQMon1PfCn5onSi1lPec="
-            Outline: "7Pb1TvYRzbV2wqtFSrQIw0aqGFh7QstFaeuHBf3DQZk="
-        32:
-            Duotone: "bxpDMAljGKNDaaIQvVtNwnGvxBZiAt+9/nIT0tEb0M0="
-            Fill: "Ljbr0YvrXbggfd/Ol/lHTQ0zLNkGNta+OfNwjOYaTtI="
-            Outline: "m/76aRpyzERAO9412uOxc4aYUN98uvTLcmqK6+0wnXQ="
-        64:
-            Duotone: "L8y3Uq9e6vdJY1TAHTlgoy/qS/KaldOgzARbrQx0tOI="
-            Fill: "VI4XjNYtNAyfKz5UuM3c5+s1zc+vSIlTtR65ExWDR2g="
-            Outline: "l511R1nh7zS9AHB/FXHQ1NIB1wSsMvCZj645LS0P6GI="
+        Size=Default, Style=Default: "7Pb1TvYRzbV2wqtFSrQIw0aqGFh7QstFaeuHBf3DQZk="
 
     Icon/Downvote:
-        20:
-            Duotone: yMY81gkFoTvSYCm0BGPBZHgjhrOjQANAj+Sfb1EdOlQ=
-            Fill: nOnVH1vUn8zVjmg8BWd68WK5BedTOcWvo0Uo3OETteM=
-            Outline: m/OsUqAEX5B7ROu0ILneCRp3mb6ETN7WP1hR0VJ1Dn0=
-        24:
-            Duotone: MgDMMPkhN117RowLFRgPK5iBV36eir2VkL1XSjEim2o=
-            Fill: rYGF3edaX/Pr92i8nCSsJCUV9s6q+tpBmIVDRMsaP+Q=
-            Outline: WttPSUqHXdrTqo00F0gmpYUlKWgJQw+5HoS0M5K88Nk=
-        32:
-            Duotone: L6m69wikVLoQKaRqjgIRSC5Vaw5zPrv5Ad/gmmZgDRQ=
-            Fill: JlOrF8rFwmq2R4pCucsiwGEpo2CEA6qM3uA6Y0s94FU=
-            Outline: aLLdCa2PY8YkccrJbjekbbibaruu+loQP9G3WbQcYTs=
-        64:
-            Duotone: Lt1Gf+5CzJF3pdhmZbVnu0eFxrCKT5YbwA1Z5QVwhmE=
-            Fill: 4B9PYIzLagRA6vto78bb8bLRR7NFAAfEYM/rt23iM7M=
-            Outline: knofxIuMYhmdymG6C/IL2tuonImlybdmg1m2w/0dykU=
+        Size=Default, Style=Default: /OfUswkQOjHqmT/tPFbJxXrvkHwXk1M+WzSIV0LtwqU=
 
     Icon/Home:
-        20:
-            Duotone: "IsuGYnZ329Mg1MNX2LJZvU99+aIyxXgzu2+u8t6bJBQ="
-            Fill: "Gppd5eUt1tuEUnIbxhRISj+Dh0E3av0J0egRmnfy/yw="
-            Outline: "PoAKhksimke9mURtwprpur5c1Pdg3DX/JSoQkhpAZoo="
-        24:
-            Duotone: "C/RxPHvaTJn7IDpdBKUevqmKd+l1c+TeWP8qrIge5KI="
-            Fill: "0QGIG8t77JXJMaycDkwScjTorLKekviMETFQJjwkR+M="
-            Outline: "55XLf0sI9KjeXEceqbdqwSOYWoR7KpMPfP47mCzBNdI="
-        32:
-            Duotone: "oQ0lb3e72lBQLP+m78za1DF6uTrlDSuQZ+Iw7UOscgM="
-            Fill: "8/TQs0jCz/ay/qPj0sOl1m9oNieCJWPG7x7Rrgoo3mU="
-            Outline: "rlQ+Rb69EU+6Xar/hBag/cs/H2SNZsIQ2x6L2U0cg20="
-        64:
-            Duotone: "kng6W7XhrIiVLFSaVUaDEJ71TPZcKBRuRf0aXj1B44w="
-            Fill: "C1QKOWzEYHTzV9En2nViRw8eY/x6/iuKcNkPe1ngxOI="
-            Outline: "8tg9GfEF8WY98Z7MrLiBp70tTsZeL9PyxxnoUndD/gI="
+        Size=Default, Style=Default: "55XLf0sI9KjeXEceqbdqwSOYWoR7KpMPfP47mCzBNdI="
 
     Icon/Question:
-        20:
-            Duotone: a3F6CA+0wh8zso2zpLc2cR2j7dxgTIfRTamptjGLNoA=
-            Fill: MxkrhSkfEU3t2XD9BUGRPwY9SRntZh3AyGUPEEmvAys=
-            Outline: uJkV1eH3NGwHaRBXUyGawMLauGBECQPD5nU9QbQwA88=
-        24:
-            Duotone: YaWL55DfVKxx1raeY7aGOH1b2YOFmvOR+uFIHDlkdAY=
-            Fill: kJbP8ttjkDDvdyW9SEpevA+ZFcopzph+8uiUFcBRnYo=
-            Outline: k5BlX0M0jZTz0UJif35AM5ZQAo7jtHVHSOI7b/zw2jM=
-        32:
-            Duotone: jXhso1kTL1uRCHwHh2FR68NVvGL8U13VKujuRLBDZ+k=
-            Fill: nX2mcv7np2ACigIN3tnR/kuB8VE9Ha0XYyCaMNL9pms=
-            Outline: 3pqy1Sh3kcSmmwEIkD/rmCGOuKpt7zPTk1/CmXdBgOY=
-        64:
-            Duotone: jCx7Va5WGbylgwf6X0E9ATh4DaS4fTVG07+tJBNxtRM=
-            Fill: qqyjf8XvpzSIQXb7KeRq7oFEXf2u6MMZOLiU68rcajU=
-            Outline: TRgo7VKPHVZSOTEBePkHHuKjDJiE0js9H2IyO6ozgrE=
+        Size=Default, Style=Default: k5BlX0M0jZTz0UJif35AM5ZQAo7jtHVHSOI7b/zw2jM=
 
     Icon/Questions:
-        20:
-            Duotone: 6ld3CPrbQTIyMAzLKDAmk2snA5ttRiCCw3Y6ZpUETio=
-            Fill: wC6gwZsYgsVZR3myjuEDwar3Uoj0/0l6TSvVQhV64OQ=
-            Outline: K2v6gQ4LybbU57O43TRiDCQ0vjTS1yYb3pVpdbOuGzI=
-        24:
-            Duotone: jaqXedMGV7xx3zR9AXjuHquiZ4sri/zkZcA7kks+PVU=
-            Fill: P+rQ6uNbMMZsEy36R3iTzUYELVvTjUoF6FUgHR9obnE=
-            Outline: KfbXukyfZ/c+1TRkPdpCWm2ApNverRkb6gugb6BUgss=
-        32:
-            Duotone: nqSAYV96WfJ6U6JD+f7qkfhxnc7R5knsutpB131hmrQ=
-            Fill: eGcDWYGFmxwoEolGfQC053D867WRnm0s2H/R53gYLjs=
-            Outline: 9TEt/M++GduYu0G37517p/iFLmexiXpTuBZ6QSMA+R0=
-        64:
-            Duotone: 8cV6smRonENtnArj0OutUG0ol/D3Yzr6DKYdYbb9+uY=
-            Fill: /bJXjh7VqPESScQJPa8KSCUczSF1GJIGhTLAZCdctEs=
-            Outline: +U8DWWQzJ0eZd980ccKNpjjo/JO9WQ6chtRj7y7w4jI=
+        Size=Default, Style=Default: KfbXukyfZ/c+1TRkPdpCWm2ApNverRkb6gugb6BUgss=
 
     Icon/Tag:
-        20:
-            Duotone: MCN3Mj32LufequfU8ooQpdqsoGJ0UFM6FmP5vG+U2ag=
-            Fill: z/MxNQ3RNBYOHnfxDb5dZI8FEoLxKbVskW+nkjdiF6Y=
-            Outline: T1klaa7Zj1zxk797T2n0RafV3ukYhe7+Cn1xSv2HrjQ=
-        24:
-            Duotone: 2o8fahsbwPK59oKyZoePiEZ2MUYakMfMDsRSf6u+8cE=
-            Fill: iis0D4LnOzJlxAoKPpaxlQPitrMatsRL6RFjBxOV6Zg=
-            Outline: rvgD+Pg6trm1QUfJo0abYrx+2LUTtIfbugB9Tzurfg8=
-        32:
-            Duotone: EygC+1YOWV3jix2swROF6Vjbp3oJF1HUftP/yUXXVHA=
-            Fill: dkqO+4lmMakiSdxHg3NV7Na1sqoK6ybgS1qlviFgqLs=
-            Outline: GsPfdqPTNyTp9EmB1t+LaycmTxe4R0CmH1QxN5IEZgc=
-        64:
-            Duotone: 3APSQfUIGg5xI6f4U5zrCR0sUZ17KDRhB/MQOmAyR1o=
-            Fill: /USyZi95/qLszxE7HhVnCxO4YPHrcOlackVQRyHCkfs=
-            Outline: 0qdmVhcUEy4Fe4ZtWf3bBbDWzrO5HpC4Vy3v7gJmZD4=
+        Size=Default, Style=Default: rvgD+Pg6trm1QUfJo0abYrx+2LUTtIfbugB9Tzurfg8=
 
     Icon/Tags:
-        20:
-            Duotone: wmT4WxoHlsP/7mWCU3l2F4Vc4pTl9NwXfCaT9sYB/DQ=
-            Fill: QCAsIE79DiZ++SeFcgIS3rM7nSa8J0kk+M3LWJHVck4=
-            Outline: f2A++4TNcT5Q+gu+++yVqfgTQrWZe68TGDCb1C8dNwc=
-        24:
-            Duotone: Q3ZtkzEuz3+XSsc22KhiYrq8rCSUwRo3DsNplImSZbY=
-            Fill: ZhD0n/LOISY+ckVQS8rA2T8Cix1BO+CFh5TMKddUapM=
-            Outline: V7D24XI43t8n7rKKlg013n8xVXJBfJJUm0K2kGLfPps=
-        32:
-            Duotone: qz2FAcdev5s102BlJ5frXsvmISMROB70cZLMcjZQW3w=
-            Fill: chjzRyobHnSctnxZDjIQhGu76/PJw345FlSRsMV+EDE=
-            Outline: Nqo5Wjc65G3SRK0iHM2TPjJ2HxNPEx7+r7djsjRgSa0=
-        64:
-            Duotone: qefrbU1QtqvqcZ09YXPqSu801tDV7KpZ7gqHchlGsuY=
-            Fill: U4PO6GXQd/7XavoRdHbIaMYjmaCsZ3WBRhxHV1RKIJ4=
-            Outline: qlMDapOEsgJETJ/2jE/s0cFg8ioC3Pfx9eA/Abp2Nkw=
+        Size=Default, Style=Default: V7D24XI43t8n7rKKlg013n8xVXJBfJJUm0K2kGLfPps=
 
     Icon/Upvote:
-        20:
-            Duotone: 933TBCkeBPjg+Z9d7pbpS/Ou9GYrMtErO2dowgpqZM4=
-            Fill: csCqiXxjdGbMFrBQeO8VY6SgupICAK09MIxuUb8Nck4=
-            Outline: jOOd+XI8vy9cJNqbXSL9MXPadQyem6fUqvXyJNwWvaM=
-        24:
-            Duotone: 9mJxF+YBKMYLEG6XdFJ17qBNOmQRfe+XozPf9f3AU9o=
-            Fill: WJCrS4gF8StMJEbebW5kgYS74N+jvllrO2TbtDHwE3U=
-            Outline: CQWVcxmsphMOjeEXJymcT7jR5X03aeCZxS29pI9pJbA=
-        32:
-            Duotone: EKaeKy1r1uDuAo+ZG6gupUfff2XDIBftmBWywmHHZ68=
-            Fill: dmXZ8ESMXFIpOsYh2L6YjlKiEDon+8LTwKqB14MuLcU=
-            Outline: xy5IHpcbeG1LMkgps9j6dMD9oJlP5xGyPjWzUdDEZ2c=
-        64:
-            Duotone: MslHanJcpkRde/1hfmGbPhhPCXjH6IQNllrpkr4Hgro=
-            Fill: abn5C6hg5eHYNd8XbWTYn4zgLEmtWVNBjPFfsKd5hR0=
-            Outline: lYtBSefxloDWSh4qDtGBhnZQf3Xn64dQ8xgLjhpdFtw=
+        Size=Default, Style=Default: CQWVcxmsphMOjeEXJymcT7jR5X03aeCZxS29pI9pJbA=
 
     ### SPOTS ###
     Spot/Test: "cgbl8iMviW3pIYnKyf1+vyH7e1gsGMlwxzIdPCfD5os="
@@ -222,7 +42,7 @@ definitions:
 
 ### CSS ICONS ###
 cssIcons:
-    Answer20Duotone:
+    Answer:
         css: |
             width: 20px;
             height: 20px;

--- a/dotnet/src/README.md
+++ b/dotnet/src/README.md
@@ -11,11 +11,11 @@ This package provides an SVG helper for use in Razor and other contexts:
 
 <div>
   // icons and spots return an `HtmlString` for safe use in Razor
-  @Svg.Answer20Duotone
+  @Svg.Answer
   @Svg.Spot.Wave
 
   // the `With` method can take css classes and title text to add to the svg
-  @Svg.Answer20Duotone.With(cssClass: "fc-danger", title: "foo")
+  @Svg.Answer.With(cssClass: "fc-danger", title: "foo")
 </div>
 ```
 
@@ -24,8 +24,8 @@ Enum definitions and lookup dictionaries for all icons/spots are also provided:
 ```cs
 using StackExchange.StacksIcons;
 
-StacksIcon iconName = StacksIcon.Answer20Duotone;
-HtmlString icon = Svg.Lookup[iconName]; // icon is now set to the value in Svg.Answer20Duotone
+StacksIcon iconName = StacksIcon.Answer;
+HtmlString icon = Svg.Lookup[iconName]; // icon is now set to the value in Svg.Answer
 
 StacksSpot spotName = StacksSpot.Wave;
 HtmlString spot = Svg.Spot.Lookup[spotName]; // spot is now set to the value in Svg.Spot.Wave

--- a/dotnet/test/Svg.test.cs
+++ b/dotnet/test/Svg.test.cs
@@ -5,7 +5,7 @@ public class SvgTest
     [Fact]
     public void FindsEmbeddedResources()
     {
-        var icon = Svg.Answer20Duotone;
+        var icon = Svg.Answer;
         var spot = Svg.Spot.Test;
         Assert.False(string.IsNullOrWhiteSpace(icon.Value));
         Assert.False(string.IsNullOrWhiteSpace(spot.Value));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "@stackoverflow/stacks-icons",
             "version": "7.0.0-beta.0",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "devDependencies": {
                 "@rollup/plugin-typescript": "^12.1.2",
                 "@stackoverflow/eslint-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "version": "tsc && node --no-warnings --loader ts-node/esm ./scripts/sync-dotnet-version.ts",
         "lint": "prettier --check . && eslint .",
         "format": "prettier --write .",
+        "format:config": "yq eval 'sort_keys(..)' config.yaml -i --indent 4 --prettyPrint",
         "build:nuget": "dotnet build -c Release ./dotnet",
         "pack:nuget": "dotnet pack -c Release ./dotnet",
         "test:nuget": "dotnet test ./dotnet"

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -29,7 +29,7 @@ export interface Definitions {
 
 // Helper for dealing with Figma component variants
 // Expects something like "Size=20, Style=Fill"
-export function flattenFigmaComponentVarientName(name: string): string {
+export function flattenFigmaComponentVariantName(name: string): string {
     return name // Format will be Property=Value, ...
         .split(",") // split by commas ['Prop=Val', ...]
         .map(
@@ -51,7 +51,7 @@ export function flattenDefinitions(defs: Definitions): Record<string, string> {
             out[iconName] = iconValue;
         } else {
             for (const [variant, hash] of Object.entries(iconValue)) {
-                const flattened = flattenFigmaComponentVarientName(variant);
+                const flattened = flattenFigmaComponentVariantName(variant);
                 out[iconName + flattened] = hash;
             }
         }

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -54,7 +54,6 @@ export function flattenDefinitions(defs: Definitions): Record<string, string> {
                 const flattened = flattenFigmaComponentVarientName(variant);
                 out[iconName + flattened] = hash;
             }
-
         }
     }
 

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -24,7 +24,7 @@ export function error(...args: unknown[]) {
 }
 
 export interface Definitions {
-    [iconName: string]:| string | Record<string, string>;
+    [iconName: string]: string | Record<string, string>;
 }
 
 // Helper for dealing with Figma component variants
@@ -40,7 +40,7 @@ export function flattenFigmaComponentVarientName(name: string): string {
                     .trim() || ""
         )
         .join("")
-        .replace(/Default/g, "") // any values using default are flattened
+        .replace(/Default/g, ""); // any values using default are flattened
 }
 
 export function flattenDefinitions(defs: Definitions): Record<string, string> {

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -23,8 +23,24 @@ export function error(...args: unknown[]) {
     console.error(chalk.red.bold("ERROR"), chalk.red(...args));
 }
 
-interface Definitions {
-    [iconName: string]: string | Record<string, Record<string, string>>;
+export interface Definitions {
+    [iconName: string]:| string | Record<string, string>;
+}
+
+// Helper for dealing with Figma component variants
+// Expects something like "Size=20, Style=Fill"
+export function flattenFigmaComponentVarientName(name: string): string {
+    return name // Format will be Property=Value, ...
+        .split(",") // split by commas ['Prop=Val', ...]
+        .map(
+            (i) =>
+                i
+                    .split("=")[1] // split by = and take the right side as Figma UI does
+                    ?.replace(/\s+/g, "") // trim any whitespace
+                    .trim() || ""
+        )
+        .join("")
+        .replace(/Default/g, "") // any values using default are flattened
 }
 
 export function flattenDefinitions(defs: Definitions): Record<string, string> {
@@ -34,11 +50,11 @@ export function flattenDefinitions(defs: Definitions): Record<string, string> {
         if (typeof iconValue === "string") {
             out[iconName] = iconValue;
         } else {
-            for (const [size, variants] of Object.entries(iconValue)) {
-                for (const [variant, hash] of Object.entries(variants)) {
-                    out[`${iconName}${size}${variant}`] = hash;
-                }
+            for (const [variant, hash] of Object.entries(iconValue)) {
+                const flattened = flattenFigmaComponentVarientName(variant);
+                out[iconName + flattened] = hash;
             }
+
         }
     }
 

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -47,7 +47,7 @@ export function flattenFigmaComponentVariantName(name: string): string {
             // Otherwise use the value, as before
             return val;
         })
-        .join("")
+        .join("");
 }
 
 export function flattenDefinitions(defs: Definitions): Record<string, string> {

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -28,19 +28,26 @@ export interface Definitions {
 }
 
 // Helper for dealing with Figma component variants
-// Expects something like "Size=20, Style=Fill"
+// Expects something like "Size=20, Style=Fill" or "Prop=True"
 export function flattenFigmaComponentVariantName(name: string): string {
-    return name // Format will be Property=Value, ...
+    return name
         .split(",") // split by commas ['Prop=Val', ...]
-        .map(
-            (i) =>
-                i
-                    .split("=")[1] // split by = and take the right side as Figma UI does
-                    ?.replace(/\s+/g, "") // trim any whitespace
-                    .trim() || ""
-        )
+        .map((pair) => {
+            const [prop, valRaw] = pair.split("=").map((s) => s.trim());
+            const val = String(valRaw ?? "").replace(/\s+/g, "");
+
+            // Skip "Default" values or False props
+            if (val === "Default" || val === "" || val === "False") return "";
+
+            // If it is a faux boolean, use that prop in the name
+            if (val === "True") {
+                return prop;
+            }
+
+            // Otherwise use the value, as before
+            return val;
+        })
         .join("")
-        .replace(/Default/g, ""); // any values using default are flattened
 }
 
 export function flattenDefinitions(defs: Definitions): Record<string, string> {

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -69,7 +69,10 @@ function buildIconManifestHtml(iconsObj: IconsObject): string {
                             <div class="fs-fine ff-mono fc-light pb2" title="${variantKey}">
                                 ${iconName}
                             </div>
-                            <div class="icon-preview">${svg}</div>
+                            <div class="icon-preview">${svg.replace(
+                                `class="`,
+                                `class="native `
+                            )}</div>
                         </div>
                     `;
                 })
@@ -93,7 +96,10 @@ export function buildSpotManifestHtml(iconsObj: Record<string, string>) {
             ([iconName, svg]) =>
                 `<div class="ta-center">
             <span class="fc-light">${iconName}</span>
-            <div class="mt12">${svg}</div>
+            <div class="mt12">${svg.replace(
+                `class="`,
+                `class="native `
+            )}</div>
           </div>`
         )
         .join("\n");

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -96,10 +96,7 @@ export function buildSpotManifestHtml(iconsObj: Record<string, string>) {
             ([iconName, svg]) =>
                 `<div class="ta-center">
             <span class="fc-light">${iconName}</span>
-            <div class="mt12">${svg.replace(
-                `class="`,
-                `class="native `
-            )}</div>
+            <div class="mt12">${svg.replace(`class="`, `class="native `)}</div>
           </div>`
         )
         .join("\n");

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import { paths } from "./paths.js";
 import { configRaw } from "../definitions.js";
-import { flattenFigmaComponentVariantName } from "./utils.js"
+import { flattenFigmaComponentVariantName } from "./utils.js";
 
 function buildCssManifestHtml(
     iconsObj: {
@@ -23,7 +23,9 @@ function buildCssManifestHtml(
 function buildIconManifestHtml(iconsObj: any) {
     const grouped: any = {};
 
-    for (const [figmaKey, variants] of Object.entries((configRaw.definitions))) {
+    for (const [figmaKey, variants] of Object.entries(
+        configRaw.definitions as any
+    )) {
         if (!figmaKey.startsWith("Icon/")) continue;
 
         const baseName = String(figmaKey).replace(/^Icon\//, "");
@@ -31,12 +33,19 @@ function buildIconManifestHtml(iconsObj: any) {
         if (!grouped[baseName]) grouped[baseName] = {};
 
         for (const [variantKey] of Object.entries(variants as any)) {
-            const flatName = flattenFigmaComponentVariantName(String(variantKey));
+            const flatName = flattenFigmaComponentVariantName(
+                String(variantKey)
+            );
             const iconName = baseName + (flatName ? flatName : "");
             const svg = (iconsObj as any)[iconName];
 
             if (svg) {
-                grouped[baseName][baseName + flatName] = String(svg);
+                grouped[baseName][iconName] = {
+                    svg: String(svg),
+                    variantKey,
+                    flatName: flatName || "Default",
+                    iconName,
+                };
             }
         }
     }
@@ -44,18 +53,23 @@ function buildIconManifestHtml(iconsObj: any) {
     const html = Object.entries(grouped as any)
         .map(([baseName, variants]: any) => {
             const variantsHtml = Object.entries(variants as any)
-                .map(([variantName, svg]: any) => {
+                .map(([iconName, props]: any) => {
                     return `
-                        <div class="icon-variant bb bc-black-200 py4">
-                            <span class="fs-fine ff-mono fc-light pb12">${variantName}</span>
-                            <div class="icon-preview">${String(svg)}</div>
+                        <div class="icon-variant bb bc-black-200 py4"
+                             data-base="${baseName}"
+                             data-icon="${iconName}"
+                             data-variant="${props.flatName}">
+                            <div class="fs-fine ff-mono fc-light pb2" title="${props.variantKey}">
+                                ${iconName}
+                            </div>
+                            <div class="icon-preview">${String(props.svg)}</div>
                         </div>
                     `;
                 })
                 .join("\n");
 
             return `
-                <div class="icon-group">
+                <div class="icon-group" data-base="${baseName}">
                     <h3 class="icon-title bb bc-black-500 pb8">${baseName}</h3>
                     <div class="icon-grid">${variantsHtml}</div>
                 </div>

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -1,5 +1,7 @@
 import { promises as fs } from "fs";
 import { paths } from "./paths.js";
+import { configRaw } from "../definitions.js";
+import { flattenFigmaComponentVariantName } from "./utils.js"
 
 function buildCssManifestHtml(
     iconsObj: {
@@ -18,7 +20,53 @@ function buildCssManifestHtml(
         .join("\n\n");
 }
 
-export function buildSvgManifestHtml(iconsObj: Record<string, string>) {
+function buildIconManifestHtml(iconsObj: any) {
+    const grouped: any = {};
+
+    for (const [figmaKey, variants] of Object.entries((configRaw.definitions))) {
+        if (!figmaKey.startsWith("Icon/")) continue;
+
+        const baseName = String(figmaKey).replace(/^Icon\//, "");
+
+        if (!grouped[baseName]) grouped[baseName] = {};
+
+        for (const [variantKey] of Object.entries(variants as any)) {
+            const flatName = flattenFigmaComponentVariantName(String(variantKey));
+            const iconName = baseName + (flatName ? flatName : "");
+            const svg = (iconsObj as any)[iconName];
+
+            if (svg) {
+                grouped[baseName][baseName + flatName] = String(svg);
+            }
+        }
+    }
+
+    const html = Object.entries(grouped as any)
+        .map(([baseName, variants]: any) => {
+            const variantsHtml = Object.entries(variants as any)
+                .map(([variantName, svg]: any) => {
+                    return `
+                        <div class="icon-variant bb bc-black-200 py4">
+                            <span class="fs-fine ff-mono fc-light pb12">${variantName}</span>
+                            <div class="icon-preview">${String(svg)}</div>
+                        </div>
+                    `;
+                })
+                .join("\n");
+
+            return `
+                <div class="icon-group">
+                    <h3 class="icon-title bb bc-black-500 pb8">${baseName}</h3>
+                    <div class="icon-grid">${variantsHtml}</div>
+                </div>
+            `;
+        })
+        .join("\n");
+
+    return html;
+}
+
+export function buildSpotManifestHtml(iconsObj: Record<string, string>) {
     return Object.entries(iconsObj)
         .map(
             ([key, value]) =>
@@ -45,8 +93,8 @@ export async function writeManifests(
     const builtCss = await fs.readFile(paths.build("icons.css"), "utf8");
     let htmlOut = await fs.readFile(paths.src("index.html"), "utf8");
     htmlOut = htmlOut
-        .replace("{ICONS_MANIFEST}", buildSvgManifestHtml(icons))
-        .replace("{SPOTS_MANIFEST}", buildSvgManifestHtml(spots))
+        .replace("{ICONS_MANIFEST}", buildIconManifestHtml(icons))
+        .replace("{SPOTS_MANIFEST}", buildSpotManifestHtml(spots))
         .replace("{CSS_MANIFEST}", buildCssManifestHtml(cssIconsObj))
         .replace("{CSS_STYLES}", `<style>${builtCss}</style>`);
     const p1 = fs.writeFile(paths.preview("index.html"), htmlOut, "utf8");

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -20,49 +20,65 @@ function buildCssManifestHtml(
         .join("\n\n");
 }
 
-function buildIconManifestHtml(iconsObj: any) {
-    const grouped: any = {};
+interface IconEntry {
+    svg: string;
+    variantKey: string;
+    flatName: string;
+    iconName: string;
+}
 
-    for (const [figmaKey, variants] of Object.entries(
-        configRaw.definitions as any
-    )) {
+interface GroupedIcons {
+    [baseName: string]: Record<string, IconEntry>;
+}
+
+interface IconsObject {
+    [iconName: string]: string;
+}
+
+// interface FigmaDefinitions {
+//     [key: string]: Record<string, string>;
+// }
+
+function buildIconManifestHtml(iconsObj: IconsObject): string {
+    const grouped: GroupedIcons = {};
+
+    for (const [figmaKey, variants] of Object.entries(configRaw.definitions)) {
         if (!figmaKey.startsWith("Icon/")) continue;
 
-        const baseName = String(figmaKey).replace(/^Icon\//, "");
+        const baseName = figmaKey.replace(/^Icon\//, "");
 
         if (!grouped[baseName]) grouped[baseName] = {};
 
-        for (const [variantKey] of Object.entries(variants as any)) {
-            const flatName = flattenFigmaComponentVariantName(
-                String(variantKey)
-            );
+        for (const [variantKey] of Object.entries(variants)) {
+            const flatName = flattenFigmaComponentVariantName(variantKey);
             const iconName = baseName + (flatName ? flatName : "");
-            const svg = (iconsObj as any)[iconName];
+            const svg = iconsObj[iconName];
 
             if (svg) {
                 grouped[baseName][iconName] = {
-                    svg: String(svg),
-                    variantKey,
-                    flatName: flatName || "Default",
+                    flatName,
                     iconName,
+                    svg,
+                    variantKey,
                 };
             }
         }
     }
 
-    const html = Object.entries(grouped as any)
-        .map(([baseName, variants]: any) => {
-            const variantsHtml = Object.entries(variants as any)
-                .map(([iconName, props]: any) => {
+    const html = Object.entries(grouped)
+        .map(([baseName, variants]) => {
+            const variantsHtml = Object.entries(variants)
+                .map(([iconName, props]) => {
+                    const { svg, variantKey, flatName } = props;
                     return `
                         <div class="icon-variant bb bc-black-200 py4"
                              data-base="${baseName}"
                              data-icon="${iconName}"
-                             data-variant="${props.flatName}">
-                            <div class="fs-fine ff-mono fc-light pb2" title="${props.variantKey}">
+                             data-variant="${flatName}">
+                            <div class="fs-fine ff-mono fc-light pb2" title="${variantKey}">
                                 ${iconName}
                             </div>
-                            <div class="icon-preview">${String(props.svg)}</div>
+                            <div class="icon-preview">${svg}</div>
                         </div>
                     `;
                 })

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -35,10 +35,6 @@ interface IconsObject {
     [iconName: string]: string;
 }
 
-// interface FigmaDefinitions {
-//     [key: string]: Record<string, string>;
-// }
-
 function buildIconManifestHtml(iconsObj: IconsObject): string {
     const grouped: GroupedIcons = {};
 
@@ -71,10 +67,7 @@ function buildIconManifestHtml(iconsObj: IconsObject): string {
                 .map(([iconName, props]) => {
                     const { svg, variantKey, flatName } = props;
                     return `
-                        <div class="icon-variant bb bc-black-200 py4"
-                             data-base="${baseName}"
-                             data-icon="${iconName}"
-                             data-variant="${flatName}">
+                        <div class="icon-variant bb bc-black-200 py4" data-base="${baseName}" data-icon="${iconName}" data-variant="${flatName}">
                             <div class="fs-fine ff-mono fc-light pb2" title="${variantKey}">
                                 ${iconName}
                             </div>

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -90,13 +90,10 @@ function buildIconManifestHtml(iconsObj: IconsObject): string {
 export function buildSpotManifestHtml(iconsObj: Record<string, string>) {
     return Object.entries(iconsObj)
         .map(
-            ([key, value]) =>
+            ([iconName, svg]) =>
                 `<div class="ta-center">
-            <span class="fc-light">${key}</span>
-            <div class="mt12">${value.replace(
-                `class="`,
-                `class="native `
-            )}</div>
+            <span class="fc-light">${iconName}</span>
+            <div class="mt12">${svg}</div>
           </div>`
         )
         .join("\n");

--- a/scripts/build/write-manifests.ts
+++ b/scripts/build/write-manifests.ts
@@ -23,7 +23,6 @@ function buildCssManifestHtml(
 interface IconEntry {
     svg: string;
     variantKey: string;
-    flatName: string;
     iconName: string;
 }
 
@@ -52,7 +51,6 @@ function buildIconManifestHtml(iconsObj: IconsObject): string {
 
             if (svg) {
                 grouped[baseName][iconName] = {
-                    flatName,
                     iconName,
                     svg,
                     variantKey,
@@ -65,9 +63,9 @@ function buildIconManifestHtml(iconsObj: IconsObject): string {
         .map(([baseName, variants]) => {
             const variantsHtml = Object.entries(variants)
                 .map(([iconName, props]) => {
-                    const { svg, variantKey, flatName } = props;
+                    const { svg, variantKey } = props;
                     return `
-                        <div class="icon-variant bb bc-black-200 py4" data-base="${baseName}" data-icon="${iconName}" data-variant="${flatName}">
+                        <div class="icon-variant bb bc-black-200 py4"data-variant="${variantKey}">
                             <div class="fs-fine ff-mono fc-light pb2" title="${variantKey}">
                                 ${iconName}
                             </div>

--- a/scripts/build/write-svg.ts
+++ b/scripts/build/write-svg.ts
@@ -46,6 +46,8 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
     info(
         `Fetching all components from Figma ("https://figma.com/design/${process.env["FIGMA_FILE_KEY"]}")...`
     );
+
+    // https://developers.figma.com/docs/rest-api/component-endpoints/#http-endpoint-1
     const stacksFile = await fetch.get<{
         meta: { components: FigmaComponent[] };
     }>(`/files/${process.env["FIGMA_FILE_KEY"]}/components`);

--- a/scripts/build/write-svg.ts
+++ b/scripts/build/write-svg.ts
@@ -161,7 +161,7 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         const mismatchError = `Hash mismatch on ${
             hashEntries.length
         } files. Expected hash values:
-${hashEntries.reduce((p, [k, v]) => p + `"${k}": "${v}",\n`, "")}`;
+${hashEntries.reduce((p, [k, v]) => p + `${k}: ${v}\n`, "")}`;
 
         if (ignoreHashMismatch) {
             error(mismatchError);

--- a/scripts/build/write-svg.ts
+++ b/scripts/build/write-svg.ts
@@ -9,7 +9,7 @@ import {
     error,
     info,
     warn,
-    flattenFigmaComponentVarientName,
+    flattenFigmaComponentVariantName,
     type OutputType,
 } from "./utils.js";
 
@@ -65,7 +65,7 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         // For variants, loop through all of them to create seperate assets
         if (component.containing_frame?.name) {
             const componentName = component.containing_frame.name;
-            const variantName = flattenFigmaComponentVarientName(
+            const variantName = flattenFigmaComponentVariantName(
                 component.name
             );
 

--- a/scripts/build/write-svg.ts
+++ b/scripts/build/write-svg.ts
@@ -5,7 +5,7 @@ import { basename } from "path";
 import { optimize } from "svgo";
 import { definitions } from "../definitions.js";
 import { paths } from "./paths.js";
-import { error, info, warn, type OutputType } from "./utils.js";
+import { error, info, warn, flattenFigmaComponentVarientName, type OutputType } from "./utils.js";
 
 /** The upper limit to an icon's svg size in bytes */
 const MAX_ICON_SIZE_B = 4500;
@@ -59,23 +59,14 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         // For variants, loop through all of them to create seperate assets
         if (component.containing_frame?.name) {
             const componentName = component.containing_frame.name;
-            const variantName = component.name // Format will be Property=Value, ...
-                .split(",") // split by commas ['Prop=Val', ...]
-                .map(
-                    (i) =>
-                        i
-                            .split("=")[1] // split by = and take the right side as Figma UI does
-                            ?.replace(/\s+/g, "") // trim any whitespace
-                            .trim() || ""
-                )
-                .join("");
+            const variantName = flattenFigmaComponentVarientName(component.name)
 
             name = `${componentName}${variantName}`;
         }
 
         // only fetch the images that are in the definitions file
         if (!(name in definitions)) {
-            warn(`"${name}" found in Figma, but not in definitions`);
+            info(`"${name}" found in Figma, but not in definitions`);
             continue;
         }
 

--- a/scripts/build/write-svg.ts
+++ b/scripts/build/write-svg.ts
@@ -5,7 +5,13 @@ import { basename } from "path";
 import { optimize } from "svgo";
 import { definitions } from "../definitions.js";
 import { paths } from "./paths.js";
-import { error, info, warn, flattenFigmaComponentVarientName, type OutputType } from "./utils.js";
+import {
+    error,
+    info,
+    warn,
+    flattenFigmaComponentVarientName,
+    type OutputType,
+} from "./utils.js";
 
 /** The upper limit to an icon's svg size in bytes */
 const MAX_ICON_SIZE_B = 4500;
@@ -59,7 +65,9 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         // For variants, loop through all of them to create seperate assets
         if (component.containing_frame?.name) {
             const componentName = component.containing_frame.name;
-            const variantName = flattenFigmaComponentVarientName(component.name)
+            const variantName = flattenFigmaComponentVarientName(
+                component.name
+            );
 
             name = `${componentName}${variantName}`;
         }

--- a/scripts/definitions.ts
+++ b/scripts/definitions.ts
@@ -14,8 +14,9 @@ const configPath = path.resolve(
 );
 
 const configFile = await readFile(configPath, "utf-8");
-const config = YAML.parse(configFile) as Config;
 
-export const cssIcons = config.cssIcons || {};
+export const configRaw = YAML.parse(configFile) as Config;
 
-export const definitions = flattenDefinitions(config.definitions);
+export const cssIcons = configRaw.cssIcons || {};
+
+export const definitions = flattenDefinitions(configRaw.definitions);

--- a/scripts/definitions.ts
+++ b/scripts/definitions.ts
@@ -1,16 +1,10 @@
 import path from "path";
 import YAML from "yaml";
-import { flattenDefinitions } from "./build/utils.js";
+import { flattenDefinitions, type Definitions } from "./build/utils.js";
 import { readFile } from "fs/promises";
 
 export interface Config {
-    definitions: Record<
-        string, // icon name
-        Record<
-            string, // size
-            Record<string, string> // variant → hash
-        >
-    >;
+    definitions: Definitions;
     cssIcons: Record<string, { css: string }>;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,8 @@
         />
         {CSS_STYLES}
         <style>
-            body.js-unnative .svg-icon,
-            body.js-unnative .svg-svg {
+            body.js-unnative .svg-icon *,
+            body.js-unnative .svg-svg * {
                 fill: unset;
             }
             body.js-currentcolor .svg-icon {
@@ -23,54 +23,55 @@
     </head>
 
     <body>
-        <div class="mx-auto pb64 sm:pb16 px32 sm:px16 pt32 sm:pt16">
-            <div class="d-flex ai-center bb bc-black-300 pb32 mb64 sm:mb32">
-                <h2 class="fs-headline1 mb0">
-                    Icons
-                    <span class="s-badge s-badge__new lh-lg">Beta</span>
-                </h2>
-                <label
-                    for="toggle-native"
-                    class="ml-auto d-flex ai-center"
+        <div class="mx-auto pb64 sm:pb16 px32 sm:px16 pt12 sm:pt0">
+            <div class="ps-relative">
+                <div class="ps-sticky t0 bg-white d-flex ai-center bb bc-black-300 py24 mb64 sm:mb32">
+                    <h2 class="fs-headline1 mb0">
+                        Icons
+                        <span class="s-badge s-badge__new lh-lg">Beta</span>
+                    </h2>
+                    <label
+                        for="toggle-native"
+                        class="ml-auto d-flex ai-center"
+                    >
+                        <div class="d-flex ai-center g8">
+                            <label class="s-label" for="toggle-native">
+                            Override native
+                            </label>
+                            <input
+                                class="s-toggle-switch"
+                                id="toggle-native"
+                                type="checkbox"
+                            />
+                        </div>
+                    </label>
+                    <label
+                        for="toggle-currentcolor"
+                        class="ml8 d-flex ai-center"
+                    >
+                        <div class="d-flex ai-center g8">
+                            <label class="s-label" for="toggle-currentcolor">
+                                <span
+                                    class="w8 h8 d-inline-block bar-circle mr2 va-middle mtn2"
+                                    style="background: magenta"
+                                ></span>
+                                Override fill
+                            </label>
+                            <input
+                                class="s-toggle-switch"
+                                id="toggle-currentcolor"
+                                type="checkbox"
+                            />
+                        </div>
+                    </label>
+                </div>
+                <div
+                    class="d-grid grid__6 md:grid__3 sm:grid__2 gx32 gy64 sm:gx16 sm:gy32 mt32 sm:mt16"
                 >
-                    <div class="d-flex ai-center g8">
-                        <label class="s-label" for="toggle-native">
-                           Force native
-                        </label>
-                        <input
-                            class="s-toggle-switch"
-                            id="toggle-native"
-                            type="checkbox"
-                            checked="checked"
-                        />
-                    </div>
-                </label>
-                <label
-                    for="toggle-currentcolor"
-                    class="ml8 d-flex ai-center"
-                >
-                    <div class="d-flex ai-center g8">
-                        <label class="s-label" for="toggle-currentcolor">
-                            <span
-                                class="w8 h8 d-inline-block bar-circle mr2 va-middle mtn2"
-                                style="background: magenta"
-                            ></span>
-                            Override fill
-                        </label>
-                        <input
-                            class="s-toggle-switch"
-                            id="toggle-currentcolor"
-                            type="checkbox"
-                        />
-                    </div>
-                </label>
+                    {ICONS_MANIFEST}
+                </div>
             </div>
 
-            <div
-                class="d-grid grid__6 md:grid__3 sm:grid__2 gx32 gy64 sm:gx16 sm:gy32 mt32 sm:mt16"
-            >
-                {ICONS_MANIFEST}
-            </div>
             <h2 class="fs-headline1 my64 sm:my32 bb bc-black-300 pb8">
                 Spots
                 <span class="s-badge s-badge__new lh-lg">Beta</span>

--- a/src/index.html
+++ b/src/index.html
@@ -24,8 +24,8 @@
 
     <body>
         <div class="mx-auto pb64 sm:pb16 px32 sm:px16 pt32 sm:pt16">
-            <div class="d-flex ai-center bb bc-black-300 pb8 mb64 sm:mb32">
-                 <h2 class="fs-headline1">
+            <div class="d-flex ai-center bb bc-black-300 pb32 mb64 sm:mb32">
+                <h2 class="fs-headline1 mb0">
                     Icons
                     <span class="s-badge s-badge__new lh-lg">Beta</span>
                 </h2>
@@ -35,13 +35,17 @@
                 >
                     <div class="d-flex ai-center g8">
                         <label class="s-label" for="toggle-currentcolor">
-                             <span
-                                class="w8 h8 d-inline-block bar-circle mr4 va-middle"
+                            <span
+                                class="w8 h8 d-inline-block bar-circle mr2 va-middle mtn2"
                                 style="background: magenta"
-                             ></span>
+                            ></span>
                             Override fill
                         </label>
-                        <input class="s-toggle-switch" id="toggle-currentcolor" type="checkbox">
+                        <input
+                            class="s-toggle-switch"
+                            id="toggle-currentcolor"
+                            type="checkbox"
+                        />
                     </div>
                 </label>
             </div>
@@ -70,7 +74,7 @@
                 {CSS_MANIFEST}
             </div>
         </div>
-        
+
         <script>
             document
                 .getElementById("toggle-currentcolor")

--- a/src/index.html
+++ b/src/index.html
@@ -12,11 +12,11 @@
         />
         {CSS_STYLES}
         <style>
-            .svg-icon:not(.native) *,
-            .svg-spot:not(.native) * {
+            body.js-unnative .svg-icon,
+            body.js-unnative .svg-svg {
                 fill: unset;
             }
-            body.js-highlight-currentcolor .icon-preview .svg-icon {
+            body.js-currentcolor .svg-icon {
                 fill: magenta;
             }
         </style>
@@ -30,8 +30,24 @@
                     <span class="s-badge s-badge__new lh-lg">Beta</span>
                 </h2>
                 <label
-                    for="toggle-currentcolor"
+                    for="toggle-native"
                     class="ml-auto d-flex ai-center"
+                >
+                    <div class="d-flex ai-center g8">
+                        <label class="s-label" for="toggle-native">
+                           Force native
+                        </label>
+                        <input
+                            class="s-toggle-switch"
+                            id="toggle-native"
+                            type="checkbox"
+                            checked="checked"
+                        />
+                    </div>
+                </label>
+                <label
+                    for="toggle-currentcolor"
+                    class="ml8 d-flex ai-center"
                 >
                     <div class="d-flex ai-center g8">
                         <label class="s-label" for="toggle-currentcolor">
@@ -79,7 +95,13 @@
             document
                 .getElementById("toggle-currentcolor")
                 .addEventListener("change", () => {
-                    document.body.classList.toggle("js-highlight-currentcolor");
+                    document.body.classList.toggle("js-currentcolor");
+                });
+
+            document
+                .getElementById("toggle-native")
+                .addEventListener("change", () => {
+                    document.body.classList.toggle("js-unnative");
                 });
         </script>
     </body>

--- a/src/index.html
+++ b/src/index.html
@@ -25,18 +25,17 @@
     <body>
         <div class="mx-auto pb64 sm:pb16 px32 sm:px16 pt12 sm:pt0">
             <div class="ps-relative">
-                <div class="ps-sticky t0 bg-white d-flex ai-center bb bc-black-300 py24 mb64 sm:mb32">
+                <div
+                    class="ps-sticky t0 bg-white d-flex ai-center bb bc-black-300 py24 mb64 sm:mb32"
+                >
                     <h2 class="fs-headline1 mb0">
                         Icons
                         <span class="s-badge s-badge__new lh-lg">Beta</span>
                     </h2>
-                    <label
-                        for="toggle-native"
-                        class="ml-auto d-flex ai-center"
-                    >
+                    <label for="toggle-native" class="ml-auto d-flex ai-center">
                         <div class="d-flex ai-center g8">
                             <label class="s-label" for="toggle-native">
-                            Override native
+                                Override native
                             </label>
                             <input
                                 class="s-toggle-switch"

--- a/src/index.html
+++ b/src/index.html
@@ -16,17 +16,38 @@
             .svg-spot:not(.native) * {
                 fill: unset;
             }
+            body.js-highlight-currentcolor .icon-preview .svg-icon {
+                fill: magenta;
+            }
         </style>
     </head>
 
     <body>
         <div class="mx-auto pb64 sm:pb16 px32 sm:px16 pt32 sm:pt16">
-            <h2 class="fs-headline1 bb bc-black-300 pb8 mb64 sm:mb32">
-                Icons
-                <span class="s-badge s-badge__new lh-lg">Beta</span>
-            </h2>
+            <div class="d-flex ai-center bb bc-black-300 pb8 mb64 sm:mb32">
+                 <h2 class="fs-headline1">
+                    Icons
+                    <span class="s-badge s-badge__new lh-lg">Beta</span>
+                </h2>
+                <label
+                    for="toggle-currentcolor"
+                    class="ml-auto d-flex ai-center"
+                >
+                    <div class="d-flex ai-center g8">
+                        <label class="s-label" for="toggle-currentcolor">
+                             <span
+                                class="w8 h8 d-inline-block bar-circle mr4 va-middle"
+                                style="background: magenta"
+                             ></span>
+                            Override fill
+                        </label>
+                        <input class="s-toggle-switch" id="toggle-currentcolor" type="checkbox">
+                    </div>
+                </label>
+            </div>
+
             <div
-                class="d-grid grid__5 md:grid__3 sm:grid__2 gx32 gy64 sm:gx16 sm:gy32 mt32 sm:mt16"
+                class="d-grid grid__6 md:grid__3 sm:grid__2 gx32 gy64 sm:gx16 sm:gy32 mt32 sm:mt16"
             >
                 {ICONS_MANIFEST}
             </div>
@@ -49,5 +70,13 @@
                 {CSS_MANIFEST}
             </div>
         </div>
+        
+        <script>
+            document
+                .getElementById("toggle-currentcolor")
+                .addEventListener("change", () => {
+                    document.body.classList.toggle("js-highlight-currentcolor");
+                });
+        </script>
     </body>
 </html>


### PR DESCRIPTION
Updates the naming conventions for icons:

## Variant naming convention follows Figma

```yaml
ComponentName:
    Property=Value: hash123
    Property=Value, Foo=Bar: hash123
    Property=Value, Foo=Bar, Prop=True: hash123
```

Where `Prop=True`, that `Prop` is appended to the icon name (`False` is ignored).

<img width="323" height="163" alt="Screenshot 2025-10-21 at 10 12 56" src="https://github.com/user-attachments/assets/d9d45b20-59eb-4455-9696-fa249e152f43" />

## `Default` icons

Whenever a value of `Default` is used, this us removed from final icon name. Examples:

```yaml
Answer:
    Size=Default: hash123
        # Final icon name: Answer
    Size=32, Style=Default: hash123
        # Final icon name: Answer32
    Size=Default, Style=Filled: hash123
        # Final icon name: AnswerFilled
    Size=Default, Stacked=True, Style=Filled: hash123
        # Final icon name: AnswerStackedFilled
```

