### PR TITLE
chore(downloader): introduce rate limiting and retries for svg downloads

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -409,9 +409,9 @@ definitions:
         Service=MicrosoftTeams, Size=32: hHmogVtN09S3KU4Rdx/Np/ZMVVD/fVgzCvWTCIv1KSo=
         Service=MicrosoftTeams, Size=64: eahSG/30+qCmFkdqYxk0Y5QV/qMQsiR8jPLjvqB/9Lk=
         Service=MicrosoftTeams, Size=Default: BZJ3wHN4i7ZdD3Fwa+oD6toXin4sfKpe9VQonsux2AQ=
-        Service=Moveworks, Size=32: 9KhPSqJXm1Y7Im9Mm7sdzw6rqxfvXBrCZx92OHekbLk=
-        Service=Moveworks, Size=64: 2JTOrXqoifbDUjoFvcij7pnAbZ+KyIGqbALSMoXx6IY=
-        Service=Moveworks, Size=Default: NrVFqcVppGorXf9Z7YbMRapj/dODmDtLSvLus1NTDR8=
+        Service=Moveworks, Size=32: 95QQm1/0BROQb1ZIf5lOs+QucB5EjTVFTdveFTPY7Fo=
+        Service=Moveworks, Size=64: 8uf4DFCXjlXL8lGY8UdTK6Qo1qJsV6u08SamkK2Ql/k=
+        Service=Moveworks, Size=Default: MNhfjOV6oEMWlt9z5q8MRfZV8P/eibA3gTpWCwZmgRw=
         Service=Okta, Size=32: sXuhRZ1hcUaFb3l6owMQv0jc+fw0xEGi4ETnMTCIRAg=
         Service=Okta, Size=64: 4NDlo3+Al7YOO/e3bd2BShWfGyrUr5vo7yxelZsbgcs=
         Service=Okta, Size=Default: 9SjHKeGbBp53Xcx+rwcX/X8687cjQYE4HArd3o5oIaQ=
@@ -490,6 +490,8 @@ definitions:
         Size=Default, Style=32: vU7MtK2TaNI1JWHKR3vprwrS/Lrcv+UhxOXvrpHDMns=
         Size=Default, Style=Default: DU8F0IXiK6ozKXH9TfNSl9m9Yb4WPjzOTtsgfU2ul0w=
     Icon/User:
+        Size=32, Stack=False, Style=Default: rX8GZI8pWoLzcHc79LLkD13yfFPdI2NDbcxmYR2LTyw=
+        Size=32, Stack=True, Style=Default: pzSHYxh9ddIJWS+7+XpNU/q7tHFvmjPH+TyzoYG37E4=
         Size=Default, Stack=False, Style=Default: OwMdXfT7AYZdUAZKVPMhKUvRHiyjfppqzT9jcchoByE=
         Size=Default, Stack=False, Style=Fill: bbVd0b7JjY+WJlbxfFNmpi5/v9w5Jw5AGKFuOaVOc3Y=
         Size=Default, Stack=True, Style=Default: NxS6kGPXdyc46idhG3Q2AXDX4Ja+rKxGqObvpbNUd4M=
@@ -559,14 +561,14 @@ definitions:
 fills:
     # MARK: Fill maps
     # Key will be searched and replaced with value
-    "#000": null
-    "#0f2465": var(--blue-600)
-    "#200b73": var(--purple-600)
-    "#201c1d": var(--black-600)
-    "#5176f2": var(--blue-400)
-    "#590405": var(--red-600)
-    "#f0efed": var(--black-150)
-    "#fff": var(--white)
+    '#000': null
+    '#0f2465': var(--blue-600)
+    '#200b73': var(--purple-600)
+    '#201c1d': var(--black-600)
+    '#5176f2': var(--blue-400)
+    '#590405': var(--red-600)
+    '#f0efed': var(--black-150)
+    '#fff': var(--white)
     black: null
     none: null
     white: null

--- a/env.template
+++ b/env.template
@@ -11,3 +11,7 @@ ASSET_CONFIG_PATH=./config.yaml
 
 # Output folder
 ASSET_OUTPUT_DIR=./dist/
+
+# SVG downloader rate limit (requests per second)
+# Defaults to 50 if not set
+SVG_DOWNLOAD_RPS=50

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
                 "@stackoverflow/tsconfig": "^1.0.0",
                 "@types/node": "^24.10.1",
                 "axios": "^1.13.1",
+                "axios-rate-limit": "^1.4.0",
+                "axios-retry": "^4.5.0",
                 "chalk": "^5.6.2",
                 "commander": "^14.0.2",
                 "del": "^8.0.1",
@@ -1375,6 +1377,32 @@
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.4",
                 "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/axios-rate-limit": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/axios-rate-limit/-/axios-rate-limit-1.4.0.tgz",
+            "integrity": "sha512-uM5PbmSUdSle1I+59Av/wpLuNRobfatIR+FyylSoHcVHT20ohjflNnLMEHZQr7N2QVG/Wlt8jekIPhWwoKtpXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "axios": ">=0.18.0"
+            },
+            "peerDependencies": {
+                "axios": "*"
+            }
+        },
+        "node_modules/axios-retry": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+            "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "is-retry-allowed": "^2.2.0"
+            },
+            "peerDependencies": {
+                "axios": "0.x || 1.x"
             }
         },
         "node_modules/balanced-match": {
@@ -2908,6 +2936,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-retry-allowed": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+            "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -509,7 +509,6 @@
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -534,7 +533,6 @@
             "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -553,7 +551,6 @@
             "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
@@ -569,7 +566,6 @@
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -584,8 +580,7 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1067,6 +1062,7 @@
             "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
                 "@typescript-eslint/scope-manager": "5.62.0",
@@ -1102,6 +1098,7 @@
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -1262,8 +1259,7 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/acorn": {
             "version": "8.15.0",
@@ -1285,7 +1281,6 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -1296,7 +1291,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1314,7 +1308,6 @@
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1340,8 +1333,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "Python-2.0",
-            "peer": true
+            "license": "Python-2.0"
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -1373,6 +1365,7 @@
             "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.4",
@@ -1410,8 +1403,7 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/basic-auth": {
             "version": "2.0.1",
@@ -1439,7 +1431,6 @@
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1495,7 +1486,6 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1561,8 +1551,7 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/corser": {
             "version": "2.0.1",
@@ -1580,7 +1569,6 @@
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -1693,8 +1681,7 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/del": {
             "version": "8.0.1",
@@ -1791,7 +1778,6 @@
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -1996,7 +1982,6 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2143,7 +2128,6 @@
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2161,7 +2145,6 @@
             "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -2179,7 +2162,6 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -2190,7 +2172,6 @@
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2201,7 +2182,6 @@
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -2220,7 +2200,6 @@
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -2234,7 +2213,6 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -2285,7 +2263,6 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2302,8 +2279,7 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -2340,16 +2316,14 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fastq": {
             "version": "1.19.1",
@@ -2367,7 +2341,6 @@
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -2394,7 +2367,6 @@
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -2412,7 +2384,6 @@
             "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.3",
@@ -2427,8 +2398,7 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/follow-redirects": {
             "version": "1.15.11",
@@ -2473,8 +2443,7 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -2560,7 +2529,6 @@
             "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -2582,7 +2550,6 @@
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -2596,7 +2563,6 @@
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -2822,7 +2788,6 @@
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -2840,7 +2805,6 @@
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -2852,7 +2816,6 @@
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -2863,8 +2826,7 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -2959,8 +2921,7 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
@@ -2968,7 +2929,6 @@
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -2981,24 +2941,21 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/keyv": {
             "version": "4.5.4",
@@ -3006,7 +2963,6 @@
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -3017,7 +2973,6 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -3032,7 +2987,6 @@
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -3048,8 +3002,7 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -3157,7 +3110,6 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -3187,8 +3139,7 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/natural-compare-lite": {
             "version": "1.4.0",
@@ -3229,7 +3180,6 @@
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -3250,7 +3200,6 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -3269,7 +3218,6 @@
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -3286,7 +3234,6 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -3316,7 +3263,6 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -3330,7 +3276,6 @@
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3341,7 +3286,6 @@
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3352,7 +3296,6 @@
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3414,7 +3357,6 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -3438,6 +3380,7 @@
             "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -3461,7 +3404,6 @@
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3537,7 +3479,6 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -3570,7 +3511,6 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -3587,6 +3527,7 @@
             "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -3694,7 +3635,6 @@
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -3708,7 +3648,6 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3818,7 +3757,6 @@
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -3832,7 +3770,6 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -3907,8 +3844,7 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -3928,7 +3864,8 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true,
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -3972,7 +3909,6 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -3986,7 +3922,6 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4000,6 +3935,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4046,7 +3982,6 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -4077,7 +4012,6 @@
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -4094,7 +4028,6 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4104,8 +4037,7 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "2.8.2",
@@ -4129,7 +4061,6 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
         "@stackoverflow/tsconfig": "^1.0.0",
         "@types/node": "^24.10.1",
         "axios": "^1.13.1",
+        "axios-rate-limit": "^1.4.0",
+        "axios-retry": "^4.5.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "del": "^8.0.1",

--- a/scripts/build/client.ts
+++ b/scripts/build/client.ts
@@ -62,10 +62,11 @@ export function createFigmaClient(): AxiosInstance {
                 | string
                 | undefined;
             const retryAfterSeconds = Number.parseInt(String(retryAfter), 10);
+            const delaySeconds = Math.min(retryAfterSeconds, 60); // Cap at 60 seconds
             info(
-                `Rate limited by Figma API. Retrying after ${retryAfterSeconds} seconds...`
+                `Rate limited by Figma API. Retrying after ${delaySeconds} seconds...`
             );
-            return retryAfterSeconds * 1000;
+            return delaySeconds * 1000;
         },
     });
 

--- a/scripts/build/client.ts
+++ b/scripts/build/client.ts
@@ -1,0 +1,69 @@
+import axios, { type AxiosInstance } from "axios";
+import axiosRetry from "axios-retry";
+import { createRequire } from "module";
+
+// Handle CommonJS default export - axios-rate-limit is CommonJS
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rateLimit = require("axios-rate-limit") as <T extends AxiosInstance>(
+    axiosInstance: T,
+    options: {
+        maxRequests?: number;
+        perMilliseconds?: number;
+        maxRPS?: number;
+    }
+) => T;
+
+/**
+ * Creates a rate-limited axios instance for downloading SVG files.
+ * Rate limits to 50 requests per second (configurable via SVG_DOWNLOAD_RPS env var) and retries on 429 errors.
+ */
+export function createSvgClient(): AxiosInstance {
+    const maxRPS = process.env["SVG_DOWNLOAD_RPS"]
+        ? Number.parseInt(process.env["SVG_DOWNLOAD_RPS"], 10)
+        : 50;
+    const svgDownloader = rateLimit(axios.create(), {
+        maxRequests: maxRPS,
+        perMilliseconds: 1000,
+    });
+
+    // Add retry logic for SVG downloads
+    axiosRetry(svgDownloader, {
+        retries: 3,
+        retryCondition: (error) => {
+            return error.response?.status === 429;
+        },
+        retryDelay: (retryCount) => axiosRetry.exponentialDelay(retryCount),
+    });
+
+    return svgDownloader;
+}
+
+/**
+ * Creates an axios instance for Figma API calls with retry logic.
+ * Retries on 429 errors and respects the Retry-After header from Figma API responses.
+ */
+export function createFigmaClient(): AxiosInstance {
+    const figmaDownloader = axios.create({
+        baseURL: "https://api.figma.com/v1",
+        headers: { "X-Figma-Token": process.env["FIGMA_ACCESS_TOKEN"] },
+    });
+
+    // Add retry logic for Figma API calls that respects Retry-After header
+    axiosRetry(figmaDownloader, {
+        retries: 3,
+        retryCondition: (error) => {
+            return error.response?.status === 429;
+        },
+        retryDelay: (_retryCount, error) => {
+            // Retry-After is an integer in seconds, convert to milliseconds
+            const retryAfter = error.response?.headers["retry-after"] as
+                | string
+                | undefined;
+            const retryAfterSeconds = Number.parseInt(String(retryAfter), 10);
+            return retryAfterSeconds * 1000;
+        },
+    });
+
+    return figmaDownloader;
+}

--- a/scripts/build/client.ts
+++ b/scripts/build/client.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosInstance } from "axios";
 import axiosRetry from "axios-retry";
 import { createRequire } from "module";
+import { info } from "./utils.js";
 
 // Handle CommonJS default export - axios-rate-limit is CommonJS
 const require = createRequire(import.meta.url);
@@ -61,6 +62,9 @@ export function createFigmaClient(): AxiosInstance {
                 | string
                 | undefined;
             const retryAfterSeconds = Number.parseInt(String(retryAfter), 10);
+            info(
+                `Rate limited by Figma API. Retrying after ${retryAfterSeconds} seconds...`
+            );
             return retryAfterSeconds * 1000;
         },
     });

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -1,48 +1,8 @@
-import axios, { type AxiosInstance } from "axios";
-import axiosRetry from "axios-retry";
-import { createRequire } from "module";
 import chalk from "chalk";
 import { type XastElement, type PluginConfig } from "svgo";
 import { fillMap } from "../config.js";
 
 export type OutputType = "Spot" | "Icon";
-
-// Handle CommonJS default export - axios-rate-limit is CommonJS
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const rateLimit = require("axios-rate-limit") as <T extends AxiosInstance>(
-    axiosInstance: T,
-    options: {
-        maxRequests?: number;
-        perMilliseconds?: number;
-        maxRPS?: number;
-    }
-) => T;
-
-/**
- * Creates a rate-limited axios instance for downloading SVG files.
- * Rate limits to 50 requests per second (configurable via SVG_DOWNLOAD_RPS env var) and retries on 429 errors.
- */
-export function createSvgDownloader(): AxiosInstance {
-    const maxRPS = process.env["SVG_DOWNLOAD_RPS"]
-        ? Number.parseInt(process.env["SVG_DOWNLOAD_RPS"], 10)
-        : 50;
-    const svgDownloader = rateLimit(axios.create(), {
-        maxRequests: maxRPS,
-        perMilliseconds: 1000,
-    });
-
-    // Add retry logic for SVG downloads
-    axiosRetry(svgDownloader, {
-        retries: 3,
-        retryCondition: (error) => {
-            return error.response?.status === 429;
-        },
-        retryDelay: (retryCount) => axiosRetry.exponentialDelay(retryCount),
-    });
-
-    return svgDownloader;
-}
 
 /**
  * Wraps an array of promises with progress tracking.

--- a/scripts/build/utils.ts
+++ b/scripts/build/utils.ts
@@ -1,8 +1,79 @@
+import axios, { type AxiosInstance } from "axios";
+import axiosRetry from "axios-retry";
+import { createRequire } from "module";
 import chalk from "chalk";
 import { type XastElement, type PluginConfig } from "svgo";
 import { fillMap } from "../config.js";
 
 export type OutputType = "Spot" | "Icon";
+
+// Handle CommonJS default export - axios-rate-limit is CommonJS
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rateLimit = require("axios-rate-limit") as <T extends AxiosInstance>(
+    axiosInstance: T,
+    options: {
+        maxRequests?: number;
+        perMilliseconds?: number;
+        maxRPS?: number;
+    }
+) => T;
+
+/**
+ * Creates a rate-limited axios instance for downloading SVG files.
+ * Rate limits to 50 requests per second (configurable via SVG_DOWNLOAD_RPS env var) and retries on 429 errors.
+ */
+export function createSvgDownloader(): AxiosInstance {
+    const maxRPS = process.env["SVG_DOWNLOAD_RPS"]
+        ? Number.parseInt(process.env["SVG_DOWNLOAD_RPS"], 10)
+        : 50;
+    const svgDownloader = rateLimit(axios.create(), {
+        maxRequests: maxRPS,
+        perMilliseconds: 1000,
+    });
+
+    // Add retry logic for SVG downloads
+    axiosRetry(svgDownloader, {
+        retries: 3,
+        retryCondition: (error) => {
+            return error.response?.status === 429;
+        },
+        retryDelay: (retryCount) => axiosRetry.exponentialDelay(retryCount),
+    });
+
+    return svgDownloader;
+}
+
+/**
+ * Wraps an array of promises with progress tracking.
+ * Logs progress every 10 completions and when all are done.
+ */
+export function withProgressTracking<T>(
+    promises: Promise<T>[],
+    total: number,
+    label = "files"
+): Promise<T[]> {
+    let completedCount = 0;
+    const logProgress = () => {
+        completedCount++;
+        if (completedCount % 10 === 0 || completedCount === total) {
+            info(`Downloaded ${completedCount}/${total} ${label}...`);
+        }
+    };
+
+    const wrappedPromises = promises.map(async (promise) => {
+        try {
+            const result = await promise;
+            logProgress();
+            return result;
+        } catch (error) {
+            logProgress();
+            throw error;
+        }
+    });
+
+    return Promise.all(wrappedPromises);
+}
 
 function log(message: string, prefix?: string) {
     message = message.replace(/(\d+)/g, (d) => chalk.bold(d));

--- a/scripts/build/write-svg.ts
+++ b/scripts/build/write-svg.ts
@@ -12,6 +12,8 @@ import {
     flattenFigmaComponentVariantName,
     type OutputType,
     svgoPlugins,
+    createSvgDownloader,
+    withProgressTracking,
 } from "./utils.js";
 import {
     type GetFileComponentsResponse,
@@ -33,6 +35,8 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         baseURL: "https://api.figma.com/v1",
         headers: { "X-Figma-Token": process.env["FIGMA_ACCESS_TOKEN"] },
     });
+    // Create a rate-limited axios instance for downloading SVG files
+    const svgDownloader = createSvgDownloader();
 
     // Get the Stacks icon file
     info(
@@ -100,14 +104,13 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         }
     );
 
-    const queue: Promise<unknown>[] = [];
     const incorrectHashes: Record<string, string> = {};
     const images = Object.entries(urls.data.images);
-    info(`Attempting to fetch ${images.length} files from Figma...`);
+    const totalImages = images.length;
+    info(`Attempting to fetch ${totalImages} files from Figma...`);
 
-    // Loop over the object of images
-    for (const entry of images) {
-        const [node_id, url] = entry;
+    // Download images with rate limiting and retries
+    const downloadPromises = images.map(async ([node_id, url]) => {
         const name = names[node_id];
 
         if (!name || !url) {
@@ -116,41 +119,36 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
                     name
                 )}", url: "${url ?? ""}"`
             );
-            continue;
+            return;
         }
 
         const location = paths.src(`${name}.svg`);
 
-        queue.push(
-            axios
-                .get<string>(url)
-                .then((resp) => {
-                    const data = resp.data;
+        try {
+            const resp = await svgDownloader.get<string>(url);
+            const data = resp.data;
 
-                    // calculate the hash
-                    const hash = createHash("sha256");
-                    hash.update(data);
-                    const sha256 = hash.digest("base64");
+            // calculate the hash
+            const hash = createHash("sha256");
+            hash.update(data);
+            const sha256 = hash.digest("base64");
 
-                    //debug(`💾 '${name}' (${url}) ${sha256}`);
+            //debug(`💾 '${name}' (${url}) ${sha256}`);
 
-                    if (definitions[name] === sha256) {
-                        // write to file
-                        return fs.writeFile(location, data);
-                    } else {
-                        incorrectHashes[name] = sha256;
-                        // don't crash the process on a failed hash, resolve and error later
-                        return Promise.resolve();
-                    }
-                })
-                .catch((err) => {
-                    error(err);
-                })
-        );
-    }
+            if (definitions[name] === sha256) {
+                // write to file
+                await fs.writeFile(location, data);
+            } else {
+                incorrectHashes[name] = sha256;
+                // don't crash the process on a failed hash, resolve and error later
+            }
+        } catch (err) {
+            error(`Failed to fetch ${name}: ${String(err)}`);
+            throw err;
+        }
+    });
 
-    // wait for all the files to come back and be written to disk
-    await Promise.all(queue);
+    await withProgressTracking(downloadPromises, totalImages, "SVG files");
 
     const hashEntries = Object.entries(incorrectHashes).sort((a, b) => {
         if (a < b) {

--- a/scripts/build/write-svg.ts
+++ b/scripts/build/write-svg.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import fs from "fs/promises";
 import { createHash } from "node:crypto";
 import { basename } from "path";
@@ -12,9 +11,9 @@ import {
     flattenFigmaComponentVariantName,
     type OutputType,
     svgoPlugins,
-    createSvgDownloader,
     withProgressTracking,
 } from "./utils.js";
+import { createSvgClient, createFigmaClient } from "./client.js";
 import {
     type GetFileComponentsResponse,
     type GetImagesResponse,
@@ -30,13 +29,9 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         );
     }
 
-    // https://www.figma.com/developers/api
-    const fetch = axios.create({
-        baseURL: "https://api.figma.com/v1",
-        headers: { "X-Figma-Token": process.env["FIGMA_ACCESS_TOKEN"] },
-    });
-    // Create a rate-limited axios instance for downloading SVG files
-    const svgDownloader = createSvgDownloader();
+    // Create rate-limited axios instances
+    const figmaClient = createFigmaClient();
+    const svgClient = createSvgClient();
 
     // Get the Stacks icon file
     info(
@@ -44,7 +39,7 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
     );
 
     // https://developers.figma.com/docs/rest-api/component-endpoints/#http-endpoint-1
-    const stacksFile = await fetch.get<GetFileComponentsResponse>(
+    const stacksFile = await figmaClient.get<GetFileComponentsResponse>(
         `/files/${process.env["FIGMA_FILE_KEY"]}/components`
     );
 
@@ -93,7 +88,7 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
     // Returns a object of urls
     // https://www.figma.com/developers/api#get-images-endpoint
     // { "images": { "NODE_ID": "AWS URL", ... } }
-    const urls = await fetch.get<GetImagesResponse>(
+    const urls = await figmaClient.get<GetImagesResponse>(
         `/images/${process.env["FIGMA_FILE_KEY"]}`,
         {
             params: {
@@ -125,7 +120,7 @@ export const fetchFromFigma = async (ignoreHashMismatch: boolean) => {
         const location = paths.src(`${name}.svg`);
 
         try {
-            const resp = await svgDownloader.get<string>(url);
+            const resp = await svgClient.get<string>(url);
             const data = resp.data;
 
             // calculate the hash

--- a/scripts/sync-config-to-figma.ts
+++ b/scripts/sync-config-to-figma.ts
@@ -1,5 +1,4 @@
 import * as dotenv from "dotenv";
-import axios from "axios";
 import { createHash } from "node:crypto";
 import YAML from "yaml";
 import { readFile, writeFile } from "fs/promises";
@@ -8,9 +7,9 @@ import {
     success,
     info,
     warn,
-    createSvgDownloader,
     withProgressTracking,
 } from "./build/utils.js";
+import { createSvgClient, createFigmaClient } from "./build/client.js";
 import {
     GetImagesResponse,
     type GetFileComponentsResponse,
@@ -47,20 +46,16 @@ async function syncConfigFromFigma() {
 
     info("Loaded existing config.yaml");
 
-    // https://www.figma.com/developers/api
-    const fetch = axios.create({
-        baseURL: "https://api.figma.com/v1",
-        headers: { "X-Figma-Token": process.env["FIGMA_ACCESS_TOKEN"] },
-    });
-    // Create a rate-limited axios instance for downloading SVG files
-    const svgDownloader = createSvgDownloader();
+    // Create rate-limited axios instances
+    const figmaClient = createFigmaClient();
+    const svgClient = createSvgClient();
 
     info(
         `Fetching all components from Figma ("https://figma.com/design/${process.env["FIGMA_FILE_KEY"]}")...`
     );
 
     // Fetch components metadata
-    const stacksFile = await fetch.get<GetFileComponentsResponse>(
+    const stacksFile = await figmaClient.get<GetFileComponentsResponse>(
         `/files/${process.env["FIGMA_FILE_KEY"]}/components`
     );
 
@@ -147,7 +142,7 @@ async function syncConfigFromFigma() {
 
     // Fetch SVGs and calculate hashes
     const nodeIds = nodesToFetch.map((n) => n.nodeId);
-    const urls = await fetch.get<GetImagesResponse>(
+    const urls = await figmaClient.get<GetImagesResponse>(
         `/images/${process.env["FIGMA_FILE_KEY"]}`,
         {
             params: {
@@ -171,7 +166,7 @@ async function syncConfigFromFigma() {
         if (!url) return;
 
         try {
-            const resp = await svgDownloader.get<string>(url);
+            const resp = await svgClient.get<string>(url);
             const hash = createHash("sha256");
             hash.update(resp.data);
             const sha256 = hash.digest("base64");

--- a/scripts/sync-config-to-figma.ts
+++ b/scripts/sync-config-to-figma.ts
@@ -3,7 +3,14 @@ import axios from "axios";
 import { createHash } from "node:crypto";
 import YAML from "yaml";
 import { readFile, writeFile } from "fs/promises";
-import { error, success, info, warn } from "./build/utils.js";
+import {
+    error,
+    success,
+    info,
+    warn,
+    createSvgDownloader,
+    withProgressTracking,
+} from "./build/utils.js";
 import {
     GetImagesResponse,
     type GetFileComponentsResponse,
@@ -45,6 +52,8 @@ async function syncConfigFromFigma() {
         baseURL: "https://api.figma.com/v1",
         headers: { "X-Figma-Token": process.env["FIGMA_ACCESS_TOKEN"] },
     });
+    // Create a rate-limited axios instance for downloading SVG files
+    const svgDownloader = createSvgDownloader();
 
     info(
         `Fetching all components from Figma ("https://figma.com/design/${process.env["FIGMA_FILE_KEY"]}")...`
@@ -149,30 +158,31 @@ async function syncConfigFromFigma() {
         }
     );
 
-    info(`Fetching ${nodeIds.length} SVG files to calculate hashes...`);
+    const imageEntries = Object.entries(urls.data.images).filter(
+        ([, url]) => url
+    );
+    const totalImages = imageEntries.length;
+    info(`Fetching ${totalImages} SVG files to calculate hashes...`);
 
     const hashMap = new Map<string, string>();
-    const queue: Promise<void>[] = [];
 
-    for (const [nodeId, url] of Object.entries(urls.data.images)) {
-        if (!url) continue;
+    // Download images with rate limiting and retries
+    const downloadPromises = imageEntries.map(async ([nodeId, url]) => {
+        if (!url) return;
 
-        queue.push(
-            axios
-                .get<string>(url)
-                .then((resp) => {
-                    const hash = createHash("sha256");
-                    hash.update(resp.data);
-                    const sha256 = hash.digest("base64");
-                    hashMap.set(nodeId, sha256);
-                })
-                .catch((err: unknown) => {
-                    error(`Failed to fetch ${nodeId}: ${String(err)}`);
-                })
-        );
-    }
+        try {
+            const resp = await svgDownloader.get<string>(url);
+            const hash = createHash("sha256");
+            hash.update(resp.data);
+            const sha256 = hash.digest("base64");
+            hashMap.set(nodeId, sha256);
+        } catch (err: unknown) {
+            error(`Failed to fetch ${nodeId}: ${String(err)}`);
+            throw err;
+        }
+    });
 
-    await Promise.all(queue);
+    await withProgressTracking(downloadPromises, totalImages, "SVG files");
     info(`Successfully calculated ${hashMap.size} hashes`);
 
     // Update hashes in the definitions - only update what changed


### PR DESCRIPTION
This PR is 
- Rate limiting and retry requests fired by the script to download svg assets from figma (AWS) - we currently download 450+ svgs on every run.
- Retry figma api requests failing with 429s
 
Default RPS for svg downloads is set to 50 and it is configurable by an env variable. 