### PR TITLE
SPARK-98 Expose v6 Icons in a new Internal Legacy Package

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -48,4 +48,4 @@ jobs:
               run: dotnet pack -c Release ./dotnet /p:PackageId=StackExchange.StacksIcons.Legacy
 
             - name: Push package to Cloudsmith
-              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg -k ${{secrets.CLOUDSMITH_API_KEY}} -s https://nuget.stackoverflow.software/v3/index.json
+              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -43,3 +43,9 @@ jobs:
 
             - name: Push package to nuget
               run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}}
+
+            - name: Build renamed package for Cloudsmith
+              run: dotnet pack -c Release ./dotnet /p:PackageId=StackExchange.StacksIcons.Legacy
+
+            - name: Push package to Cloudsmith
+              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg -k ${{secrets.CLOUDSMITH_API_KEY}} -s https://nuget.stackoverflow.software/v3/index.json

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,10 +42,10 @@ jobs:
               run: npm run pack:nuget
 
             - name: Push package to nuget
-              run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}}
+              run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
             - name: Build renamed package for Cloudsmith
-              run: dotnet pack -c Release ./dotnet /p:PackageId=StackExchange.StacksIcons.Legacy
+              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy
 
             - name: Push package to Cloudsmith
-              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}}
+              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}} --skip-duplicate


### PR DESCRIPTION
# Summary

Because it's not possible to have two versions of the same NuGet package when using Central Package Management we decided to release an internal only version of Stacks V6 called: `StackExchange.StacksIcons.Legacy`. This additional package will allow internal consumers to use both legacy and SHINE icons at the same time.

I opted to push directly to cloudsmith to avoid having a new public NuGet package.