### PR TITLE
SPARK-98 Expose v6 Icons in a new Internal Legacy Package

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,11 +5,11 @@ on:
         tags:
             - "v*" # only run when a new package version is tagged
     workflow_dispatch:
-      inputs:
-        ignoreNpmErrors:
-          description: 'Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists.'
-          required: false
-          default: false
+        inputs:
+            ignoreNpmErrors:
+                description: "Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists."
+                required: false
+                default: false
 
 jobs:
     build-ubuntu:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -9,7 +9,7 @@ on:
             ignoreNpmErrors:
                 description: "Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists."
                 required: false
-                default: false
+                default: 'false'
 
 jobs:
     build-ubuntu:
@@ -33,7 +33,7 @@ jobs:
               run: npm ci
 
             - name: Build and push package to npm
-              continue-on-error: ${{ inputs.ignoreNpmErrors }}
+              continue-on-error: ${{ inputs.ignoreNpmErrors }} == 'true'
               env:
                   FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -9,7 +9,7 @@ on:
             ignoreNpmErrors:
                 description: "Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists."
                 required: false
-                default: 'false'
+                default: "false"
 
 jobs:
     build-ubuntu:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,9 +7,9 @@ on:
     workflow_dispatch:
       inputs:
         ignoreNpmErrors:
-        description: 'Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists.'
-        required: false
-        default: false
+          description: 'Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists.'
+          required: false
+          default: false
 
 jobs:
     build-ubuntu:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -48,4 +48,4 @@ jobs:
               run: dotnet pack -c Release ./dotnet /p:PackageId=StackExchange.StacksIcons.Legacy
 
             - name: Push package to Cloudsmith
-              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg -k ${{secrets.CLOUDSMITH_API_KEY}} -s https://nuget.stackoverflow.software/v3/index.json
+              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -33,7 +33,7 @@ jobs:
               run: npm ci
 
             - name: Build and push package to npm
-              continue-on-error: ${{ inputs.ignoreNpmErrors }} == 'true'
+              continue-on-error: ${{ inputs.ignoreNpmErrors == 'true' }}
               env:
                   FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -51,7 +51,7 @@ jobs:
               run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
             - name: Build renamed package for Cloudsmith
-              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy /p:AssemblyName=StackExchange.StacksIcons.Legacy
+              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy /p:AssemblyName=StackExchange.StacksIcons.Legacy /p:RootNamespace=StackExchange.StacksIcons.Legacy
 
             - name: Push package to Cloudsmith
               run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}} --skip-duplicate

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,6 +5,11 @@ on:
         tags:
             - "v*" # only run when a new package version is tagged
     workflow_dispatch:
+      inputs:
+        ignoreNpmErrors:
+        description: 'Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists.'
+        required: false
+        default: false
 
 jobs:
     build-ubuntu:
@@ -28,6 +33,7 @@ jobs:
               run: npm ci
 
             - name: Build and push package to npm
+              continue-on-error: ${{ inputs.ignoreNpmErrors }}
               env:
                   FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -43,3 +43,9 @@ jobs:
 
             - name: Push package to nuget
               run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}}
+
+            - name: Build renamed package for Cloudsmith
+              run: dotnet pack -c Release ./dotnet /p:PackageId=StackExchange.StacksIcons.Legacy
+
+            - name: Push package to Cloudsmith
+              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg -k ${{secrets.CLOUDSMITH_API_KEY}} -s https://nuget.stackoverflow.software/v3/index.json

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,10 +42,10 @@ jobs:
               run: npm run pack:nuget
 
             - name: Push package to nuget
-              run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}}
+              run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
             - name: Build renamed package for Cloudsmith
-              run: dotnet pack -c Release ./dotnet /p:PackageId=StackExchange.StacksIcons.Legacy
+              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy
 
             - name: Push package to Cloudsmith
-              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}}
+              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}} --skip-duplicate

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -51,7 +51,7 @@ jobs:
               run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
             - name: Build renamed package for Cloudsmith
-              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy
+              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy /p:AssemblyName=StackExchange.StacksIcons.Legacy
 
             - name: Push package to Cloudsmith
               run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}} --skip-duplicate


### PR DESCRIPTION
# Summary

Because it's not possible to have two versions of the same NuGet package when using Central Package Management we decided to release a version of Stacks V6 called: `StackExchange.StacksIcons.Legacy`. This additional package will allow internal consumers to use both legacy and SHINE icons at the same time.

I opted to push directly to cloudsmith to avoid having a new public NuGet package.