### PR TITLE
chore(netlify): redirect logos domain to icons

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[[redirects]]
+from = "https://logos.stackoverflow.design/"
+to = "https://icons.stackoverflow.design/"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://logos.stackoverflow.design/*"
+to = "https://icons.stackoverflow.design/:splat"
+status = 301
+force = true


### PR DESCRIPTION
## Summary
- Add Netlify redirects from `logos.stackoverflow.design` to `icons.stackoverflow.design`
- Preserve path suffixes and force permanent 301 redirects for the legacy hostname