### PR TITLE
Setup for NPM trusted publishing

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -10,22 +10,25 @@ on:
                 description: "Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists."
                 required: false
                 default: "false"
+permissions:
+    id-token: write # required for npm trusted publishing (OIDC)
+    contents: read
 
 jobs:
     build-ubuntu:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
                   registry-url: "https://registry.npmjs.org"
 
             - name: Install .NET SDK
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: "8.0.x" # latest LTS build
 
@@ -36,7 +39,6 @@ jobs:
               continue-on-error: ${{ inputs.ignoreNpmErrors == 'true' }}
               env:
                   FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}
               run: |
                   if [[ ${{ github.ref }} == *"rc"* ]]; then
                     npm publish --tag rc

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -111,7 +111,7 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
                   registry-url: "https://registry.npmjs.org"
 
             - name: Install .NET SDK

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -100,6 +100,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            id-token: write
         steps:
             - name: Download release artifacts
               uses: actions/download-artifact@v4
@@ -120,8 +121,6 @@ jobs:
 
             - name: Push package to npm
               if: inputs.skipNpmPublish != true
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}
               run: |
                   packages=(release-artifacts/*.tgz)
                   test ${#packages[@]} -eq 1

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
     "name": "@stackoverflow/stacks-icons",
     "description": "The icon library for Stack Overflow, Stack Overflow Careers, and the Stack Exchange Network.",
     "version": "6.9.0",
-    "repository": "https://github.com/StackExchange/Stacks-Icons",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/StackExchange/Stacks-Icons.git"
+    },
     "license": "MIT",
     "type": "module",
     "main": "dist/index.umd.cjs",


### PR DESCRIPTION
https://docs.npmjs.com/trusted-publishers

Removes the need for the `NPM_API_KEY`, mirrored on `beta` already https://github.com/StackExchange/Stacks-Icons/commit/e70019ae095e99b3118dacd79406da743944dafb

