### PR TITLE
fix(release): harden v7 package publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
     push:
-        branches: [production, beta]
+        branches: [beta, main]
     pull_request:
-        branches: [production, beta]
+        branches: [beta, main]
     workflow_dispatch:
 
 jobs:
@@ -35,6 +35,12 @@ jobs:
 
             - name: Run linters
               run: npm run lint
+
+            - name: Validate package metadata
+              run: npm run test:metadata
+
+            - name: Validate npm package
+              run: npm run test:package
 
             - name: .NET Build
               run: npm run build:nuget

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
     push:
-        branches: [beta, main]
+        branches: [production, beta, main]
     pull_request:
-        branches: [beta, main]
+        branches: [production, beta, main]
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,14 +5,20 @@ on:
         tags:
             - "v*" # only run when a new package version is tagged
     workflow_dispatch:
-
-permissions:
-    id-token: write # required for npm trusted publishing (OIDC)
-    contents: read
+        inputs:
+            skipNpmPublish:
+                description: Skip npm when retrying a partially completed release
+                required: false
+                type: boolean
+                default: false
 
 jobs:
-    build-ubuntu:
+    build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        outputs:
+            npm-tag: ${{ steps.release.outputs.npm-tag }}
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -23,6 +29,10 @@ jobs:
                   node-version: 24
                   registry-url: "https://registry.npmjs.org"
 
+            - name: Validate release ref
+              id: release
+              run: node ./scripts/prepare-release.mjs
+
             - name: Install .NET SDK
               uses: actions/setup-dotnet@v4
               with:
@@ -31,19 +41,77 @@ jobs:
             - name: Install npm dependencies
               run: npm ci
 
-            - name: Build and push package to npm
+            - name: Build packages
               env:
                   FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
                   FIGMA_FILE_KEY: Z5yoO4WH58QDHvmxwMWhr0
-              run: |
-                  if [[ ${{ github.ref }} == *"beta"* ]]; then
-                    npm publish --tag beta
-                  else
-                    npm publish --tag latest
-                  fi
+              run: npm run build
+
+            - name: Run linters
+              run: npm run lint
+
+            - name: Validate package metadata
+              run: npm run test:metadata
+
+            - name: Validate npm package
+              run: npm run test:package
 
             - name: .NET Build
+              run: npm run build:nuget
+
+            - name: .NET test
+              run: npm run test:nuget
+
+            - name: Pack NuGet package
               run: npm run pack:nuget
 
+            - name: Prepare release artifacts
+              run: |
+                  npm pack --ignore-scripts
+                  mkdir release-artifacts
+                  cp ./*.tgz release-artifacts/
+                  cp dotnet/src/bin/Release/*.nupkg release-artifacts/
+
+            - name: Upload release artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: release-packages
+                  path: release-artifacts/*
+                  if-no-files-found: error
+
+    publish:
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - name: Download release artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: release-packages
+                  path: release-artifacts
+
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Install .NET SDK
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: "8.0.x"
+
+            - name: Push package to npm
+              if: inputs.skipNpmPublish != true
+              run: |
+                  packages=(release-artifacts/*.tgz)
+                  test ${#packages[@]} -eq 1
+                  npm publish "${packages[0]}" --ignore-scripts --tag "${{ needs.build.outputs.npm-tag }}"
+
             - name: Push package to nuget
-              run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}}
+              run: |
+                  packages=(release-artifacts/*.nupkg)
+                  test ${#packages[@]} -eq 1
+                  dotnet nuget push "${packages[0]}" --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/dotnet/src/StackExchange.StacksIcons.csproj
+++ b/dotnet/src/StackExchange.StacksIcons.csproj
@@ -11,7 +11,7 @@
 	<PropertyGroup>
 		<Description>Stack Overflow's shared icon set</Description>
 		<PackageProjectUrl>https://github.com/StackExchange/Stacks-Icons</PackageProjectUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<RepositoryUrl>https://github.com/StackExchange/Stacks-Icons.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -41,6 +41,6 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="System.Collections.Immutable" Version="9.0.9" />
+		<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
 	</ItemGroup>
 </Project>

--- a/dotnet/src/StackExchange.StacksIcons.csproj
+++ b/dotnet/src/StackExchange.StacksIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
-		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<Version>7.0.0-beta.28</Version>
 		<AssemblyName>StackExchange.StacksIcons</AssemblyName>
 		<PackageId>StackExchange.StacksIcons</PackageId>
@@ -41,6 +41,6 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+		<PackageReference Include="System.Collections.Immutable" Version="9.0.9" />
 	</ItemGroup>
 </Project>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
         "format:config": "yq eval 'sort_keys(..)' config.yaml -i --indent 4 --prettyPrint",
         "build:nuget": "dotnet build -c Release ./dotnet",
         "pack:nuget": "dotnet pack -c Release ./dotnet",
+        "test:metadata": "node ./scripts/test-metadata.mjs",
+        "test:package": "node ./scripts/test-package.mjs",
         "test:nuget": "dotnet test ./dotnet"
     },
     "devDependencies": {

--- a/scripts/build/write-json.ts
+++ b/scripts/build/write-json.ts
@@ -100,7 +100,7 @@ function sortVariants(variants: ManifestVariant[]): ManifestVariant[] {
 function buildEntries(
     svgObj: Record<string, string>,
     type: OutputType,
-    componentByBuildKey: Map<string, FigmaComponent>
+    componentByFigmaName: Map<string, FigmaComponent>
 ): ManifestEntry[] {
     const result: ManifestEntry[] = [];
     const isSpot = type === "Spot";
@@ -116,7 +116,7 @@ function buildEntries(
         if (typeof variantDefs === "string") {
             // Simple component — no variant properties
             const svg = svgObj[baseName];
-            const component = componentByBuildKey.get(baseName);
+            const component = componentByFigmaName.get(`${type}/${baseName}`);
             if (svg) {
                 variants.push({
                     createdAt: component?.created_at ?? "",
@@ -136,7 +136,9 @@ function buildEntries(
                 const flatName = flattenFigmaComponentVariantName(variantKey);
                 const buildKey = baseName + flatName;
                 const svg = svgObj[buildKey];
-                const component = componentByBuildKey.get(buildKey);
+                const component = componentByFigmaName.get(
+                    `${type}/${buildKey}`
+                );
                 if (svg) {
                     variants.push({
                         createdAt: component?.created_at ?? "",
@@ -154,10 +156,22 @@ function buildEntries(
         }
 
         if (variants.length > 0) {
-            const sorted = sortVariants(variants);
+            // Figma can contain equivalent default variants whose properties
+            // flatten to the same public build key. Generated assets use the
+            // last definition, so the manifest must expose that key once too.
+            const uniqueVariants = [
+                ...new Map(
+                    variants.map((variant) => [variant.key, variant])
+                ).values(),
+            ];
+            const sorted = sortVariants(uniqueVariants);
             const description =
-                variants
-                    .map((v) => componentByBuildKey.get(v.key)?.description)
+                uniqueVariants
+                    .map(
+                        (v) =>
+                            componentByFigmaName.get(`${type}/${v.key}`)
+                                ?.description
+                    )
                     .find((d) => d) ?? "";
             result.push({
                 description,
@@ -180,19 +194,18 @@ export async function writeManifest(
     /** nodeId → full Figma name e.g. "Icon/Alert16Fill" */
     figmaNames: Record<string, string>
 ) {
-    // Map flattened build key (e.g. "Alert16Fill") → Figma component metadata
-    const componentByBuildKey = new Map<string, FigmaComponent>();
+    // Map the typed build name (e.g. "Icon/Alert16Fill") to Figma metadata.
+    const componentByFigmaName = new Map<string, FigmaComponent>();
     for (const component of figmaComponents) {
         const figmaName = figmaNames[component.node_id];
         if (!figmaName) continue;
-        const buildKey = figmaName.replace(/^(?:Icon|Spot)\//, "");
-        componentByBuildKey.set(buildKey, component);
+        componentByFigmaName.set(figmaName, component);
     }
 
     const manifest = {
         generatedAt: new Date().toISOString(),
-        icons: buildEntries(iconsObj, "Icon", componentByBuildKey),
-        spots: buildEntries(spotsObj, "Spot", componentByBuildKey),
+        icons: buildEntries(iconsObj, "Icon", componentByFigmaName),
+        spots: buildEntries(spotsObj, "Spot", componentByFigmaName),
         version: packageJson.version,
     };
 

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { appendFileSync } from "node:fs";
+import { env } from "node:process";
+import packageJson from "../package.json" with { type: "json" };
+
+assert.equal(env["GITHUB_REF_TYPE"], "tag", "Releases must run from a Git tag");
+assert.equal(
+    env["GITHUB_REF_NAME"],
+    `v${packageJson.version}`,
+    "The Git tag must match the package version"
+);
+
+const prerelease = packageJson.version.split("-", 2)[1];
+const npmTag = prerelease?.split(".", 1)[0] ?? "latest";
+
+assert.match(
+    npmTag,
+    /^(?:latest|[a-z][a-z0-9-]*)$/i,
+    "The npm dist-tag must start with a letter"
+);
+
+const githubOutput = env["GITHUB_OUTPUT"];
+assert.ok(githubOutput, "GITHUB_OUTPUT is unavailable");
+appendFileSync(githubOutput, `npm-tag=${npmTag}\n`);

--- a/scripts/test-metadata.mjs
+++ b/scripts/test-metadata.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import packageJson from "../package.json" with { type: "json" };
+
+const project = readFileSync(
+    new URL("../dotnet/src/StackExchange.StacksIcons.csproj", import.meta.url),
+    "utf8"
+);
+
+/** @param {string} name */
+function readElement(name) {
+    const match = project.match(new RegExp(`<${name}>([^<]+)</${name}>`));
+    assert.ok(match, `Missing <${name}> from the NuGet project`);
+    return match[1];
+}
+
+assert.equal(
+    readElement("Version"),
+    packageJson.version,
+    "npm and NuGet versions must match"
+);
+assert.equal(packageJson.license, "Apache-2.0");
+assert.equal(
+    readElement("PackageLicenseExpression"),
+    packageJson.license,
+    "npm and NuGet licenses must match"
+);
+assert.equal(readElement("TargetFrameworks"), "net6.0;net8.0");
+assert.match(
+    project,
+    /<PackageReference Include="System\.Collections\.Immutable" Version="8\.[^"]*" \/>/,
+    "System.Collections.Immutable must support every target framework"
+);

--- a/scripts/test-metadata.mjs
+++ b/scripts/test-metadata.mjs
@@ -25,9 +25,9 @@ assert.equal(
     packageJson.license,
     "npm and NuGet licenses must match"
 );
-assert.equal(readElement("TargetFrameworks"), "net6.0;net8.0");
+assert.equal(readElement("TargetFramework"), "net8.0");
 assert.match(
     project,
-    /<PackageReference Include="System\.Collections\.Immutable" Version="8\.[^"]*" \/>/,
-    "System.Collections.Immutable must support every target framework"
+    /<PackageReference Include="System\.Collections\.Immutable" Version="9\.[^"]*" \/>/,
+    "System.Collections.Immutable must use the current .NET 9-compatible package line"
 );

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+    mkdtempSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { env, execPath } from "node:process";
+import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+import packageJson from "../package.json" with { type: "json" };
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const temporaryDirectory = mkdtempSync(resolve(tmpdir(), "stacks-icons-"));
+const consumerDirectory = resolve(temporaryDirectory, "consumer");
+
+/** @typedef {Omit<import("node:child_process").ExecFileSyncOptionsWithStringEncoding, "encoding">} RunOptions */
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {RunOptions} [options]
+ */
+function run(command, args, options = {}) {
+    return execFileSync(command, args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "inherit"],
+        ...options,
+    });
+}
+
+/**
+ * @param {string[]} args
+ * @param {RunOptions} [options]
+ */
+function runNpm(args, options = {}) {
+    const npmExecPath = env["npm_execpath"];
+    assert.ok(npmExecPath, "Run this test through npm run test:package");
+    return run(execPath, [npmExecPath, ...args], options);
+}
+
+try {
+    const config = YAML.parse(
+        readFileSync(resolve(repositoryRoot, "config.yaml"), "utf8")
+    );
+    const cssIconNames = Object.keys(config.cssIcons ?? {});
+    const generatedCss = readFileSync(
+        resolve(repositoryRoot, "dist/icons.css"),
+        "utf8"
+    );
+
+    assert.ok(cssIconNames.length > 0, "No CSS icons are configured");
+    for (const iconName of cssIconNames) {
+        assert.match(
+            generatedCss,
+            new RegExp(`\\.svg-icon-bg\\.icon${iconName}\\s*\\{`),
+            `Missing generated CSS selector for ${iconName}`
+        );
+    }
+    const generatedCssIconNames = [
+        ...generatedCss.matchAll(/\.svg-icon-bg\.icon([A-Za-z0-9]+)\s*\{/g),
+    ].map((match) => match[1]);
+    assert.deepEqual(
+        generatedCssIconNames.sort(),
+        cssIconNames.sort(),
+        "Generated CSS selectors must match the configured CSS icons"
+    );
+
+    /** @type {{ filename: string, files: { path: string }[] }} */
+    const packResult = JSON.parse(
+        runNpm(
+            [
+                "pack",
+                "--ignore-scripts",
+                "--json",
+                "--pack-destination",
+                temporaryDirectory,
+            ],
+            { cwd: repositoryRoot }
+        )
+    )[0];
+    const packagedFiles = new Set(packResult.files.map(({ path }) => path));
+
+    for (const expectedFile of [
+        "dist/index.umd.cjs",
+        "dist/index.esm.js",
+        "dist/index.d.ts",
+        "dist/icons.js",
+        "dist/spots.js",
+        "dist/icons.css",
+        "dist/manifest.json",
+        "package.json",
+        "README.md",
+        "LICENSE.md",
+    ]) {
+        assert.ok(
+            packagedFiles.has(expectedFile),
+            `Missing ${expectedFile} from package`
+        );
+    }
+
+    mkdirSync(consumerDirectory);
+    writeFileSync(
+        resolve(consumerDirectory, "package.json"),
+        JSON.stringify({
+            name: "stacks-icons-consumer",
+            private: true,
+            type: "module",
+        })
+    );
+
+    const tarballPath = resolve(temporaryDirectory, packResult.filename);
+    runNpm(
+        [
+            "install",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--no-package-lock",
+            tarballPath,
+        ],
+        { cwd: consumerDirectory }
+    );
+
+    writeFileSync(
+        resolve(consumerDirectory, "consumer.cjs"),
+        `const assert = require("node:assert/strict");
+const { Icons, Spots } = require("@stackoverflow/stacks-icons");
+
+assert.equal(typeof Icons.IconArchive, "string");
+assert.equal(typeof Spots.SpotAds, "string");
+`
+    );
+    run(execPath, ["consumer.cjs"], { cwd: consumerDirectory });
+
+    writeFileSync(
+        resolve(consumerDirectory, "consumer.mjs"),
+        `import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import * as root from "@stackoverflow/stacks-icons";
+import * as icons from "@stackoverflow/stacks-icons/icons";
+import * as spots from "@stackoverflow/stacks-icons/spots";
+import { readFileSync } from "node:fs";
+
+const require = createRequire(import.meta.url);
+const manifestPath = require.resolve("@stackoverflow/stacks-icons/manifest");
+const cssPath = require.resolve("@stackoverflow/stacks-icons/dist/icons.css");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+assert.equal(manifest.version, ${JSON.stringify(packageJson.version)});
+assert.ok(manifest.icons.length > 0);
+assert.ok(manifest.spots.length > 0);
+assert.equal(typeof root.IconArchive, "string");
+assert.equal(root.IconArchive, icons.IconArchive);
+assert.equal(typeof spots.SpotAds, "string");
+assert.ok(readFileSync(cssPath, "utf8").includes(".svg-icon-bg"));
+
+for (const entry of [...manifest.icons, ...manifest.spots]) {
+    const exports = entry.isSpot ? spots : icons;
+    for (const variant of entry.variants) {
+        const exportName = (entry.isSpot ? "Spot" : "Icon") + variant.key;
+        assert.equal(typeof exports[exportName], "string", "Missing JS export: " + exportName);
+        const type = entry.isSpot ? "Spot" : "Icon";
+        assert.ok(require.resolve("@stackoverflow/stacks-icons/src/" + type + "/" + variant.key + ".svg"));
+        assert.ok(require.resolve("@stackoverflow/stacks-icons/dist/" + type + "/" + variant.key + ".svg"));
+    }
+}
+
+const expectedIconExports = manifest.icons.flatMap((entry) =>
+    entry.variants.map((variant) => "Icon" + variant.key)
+);
+const expectedSpotExports = manifest.spots.flatMap((entry) =>
+    entry.variants.map((variant) => "Spot" + variant.key)
+);
+assert.deepEqual(Object.keys(icons).sort(), expectedIconExports.sort());
+assert.deepEqual(Object.keys(spots).sort(), expectedSpotExports.sort());
+`
+    );
+    run(execPath, ["consumer.mjs"], { cwd: consumerDirectory });
+
+    writeFileSync(
+        resolve(consumerDirectory, "consumer.ts"),
+        `import { IconArchive } from "@stackoverflow/stacks-icons/icons";
+import { SpotAds } from "@stackoverflow/stacks-icons/spots";
+
+const icon: string = IconArchive;
+const spot: string = SpotAds;
+void [icon, spot];
+`
+    );
+    writeFileSync(
+        resolve(consumerDirectory, "tsconfig.json"),
+        JSON.stringify({
+            compilerOptions: {
+                module: "NodeNext",
+                moduleResolution: "NodeNext",
+                noEmit: true,
+                strict: true,
+                target: "ES2022",
+            },
+            include: ["consumer.ts"],
+        })
+    );
+
+    const typescriptBin = resolve(
+        repositoryRoot,
+        "node_modules/typescript/bin/tsc"
+    );
+    run(execPath, [typescriptBin, "--project", "tsconfig.json"], {
+        cwd: consumerDirectory,
+    });
+} finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- align npm and NuGet version/license/framework metadata for Icons V7
- validate packed npm exports, manifest entries, SVG paths, CSS selectors, CommonJS, ESM, and NodeNext declarations
- fix duplicate flattened manifest keys and Icon/Spot metadata collisions
- separate build/validation from registry publication so npm OIDC permission is limited to the publish job
- validate release tags, derive npm dist-tags from SemVer, and support safe NuGet recovery after partial releases

## Jira

- [STACKS-891](https://stackoverflow.atlassian.net/browse/STACKS-891)
- [STACKS-915](https://stackoverflow.atlassian.net/browse/STACKS-915) tracks the external NuGet credential repair/version reconciliation
- [STACKS-916](https://stackoverflow.atlassian.net/browse/STACKS-916) tracks V6 CI, releases, and branch protections

## Validation

- `npx tsc --noEmit`
- `npm run test:metadata`
- `npm run test:package`
- `npm run lint`
- `npm run build:nuget` — net6.0 and net8.0 build without warnings
- `npm run pack:nuget` — creates `StackExchange.StacksIcons.7.0.0-beta.28.nupkg`
- release-ref validation for `v7.0.0-beta.28` → npm tag `beta`
- `git diff --check`

## Environment limitation

- local `dotnet test` could not launch because this machine lacks the .NET 8 runtime; CI explicitly installs .NET 8 and remains the test execution gate

## Release notes

- stable `7.0.0` versioning/tagging and publication are intentionally deferred to the final release step
- V7 CSS remains intentionally curated; V6 CSS-heavy consumers remain on the preserved `v6` branch

## Accessibility

- no UI behavior changed