### PR TITLE
chore(icons): reconcile grip and list figma hashes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -258,12 +258,12 @@ definitions:
         Size=Default, Type=Default, Style=Default: zv8YXEQGjFG/wjY3UUfD0MfisPHtuAyPmv/FUH4GE1k=
         Size=Default, Type=Square, Style=Default: W6/TiBgeccz0kgaMbp4n143ERKcaH/hF6xfQiEYWf5I=
     Icon/Grip:
-        Size=16, Style=Default, Type=Default: doTJjHFKqKK9J1WO1Ld5lqq1Lu69OpLYjW7Os8Jpxp4=
-        Size=16, Style=Default, Type=H: YzjH7BtY6T9KCtAzHVbkKgymz42YUFmG4IJFJAR06k4=
-        Size=16, Style=Default, Type=V: Hf/r6vONIBwXcvIN1TMWLzv2brSERAMjwoEsAF6Cbos=
-        Size=Default, Style=Default, Type=Default: nJrsDKTcZI6NrMAkE2yfec7PTD9L7Sa4lAscjusQwbE=
-        Size=Default, Style=Default, Type=H: 3YOqq8gILMFJjHtHOCuEY0JFAcjclWt106GxY8zBglM=
-        Size=Default, Style=Default, Type=V: HPT7zi5kKeUI/ZaQyMviFiWMWiFzIUphcObHoCU1Jf0=
+        Size=16, Style=Default, Type=Default: 2Ap4px7QJW1BtYmX8ORLypIbwPrxjZYtl03K0CGq11I=
+        Size=16, Style=Default, Type=H: 264ouJ2Z1ZsGGeTd69aIDapdDkd6ZRZsufTHvQ4rmYA=
+        Size=16, Style=Default, Type=V: 5IL4rAJQ124npUPQqLap4GO4+/P/EkYRaoh6/j/w9kE=
+        Size=Default, Style=Default, Type=Default: TTEzswowAbM2BRPVU+3zRKYXOoe+CsECsJZs07Wlcrw=
+        Size=Default, Style=Default, Type=H: Z6hhH5VtN01z8CkO5smTL2zm8pDYmfsKzSpygACq+TY=
+        Size=Default, Style=Default, Type=V: 1yVVL1XzAPNVN2AoJOysN2uNywOQkrQLuGvGl2T6Zwg=
     Icon/Help:
         Size=16, Style=Fill: u93jrL7Mkz8lZla1lTggcS10BCwhopbW+3dLQiIu9Do=
         Size=32, Style=Default: 5cfvlhh0tAR2DP+pkqlyHaIcJeg1zvZABhOkB+Cr8dk=
@@ -310,8 +310,8 @@ definitions:
         Size=32, Style=Default: 1cXJJJrA/TkfhZx4jOuw2G6BpmGFnhLT9XnJmNbDcEM=
         Size=Default, Style=Default: Iwn4Ok7a4uSlPgVcy3Sp/X0rAxZBJM/zfPnOKFzDfG4=
     Icon/List:
-        Size=Default, Style=Default, Type=Default: 73KU/+cnZClCxKx22/WRDjYoUw7W7qggeV0pjackrvI=
-        Size=Default, Style=Default, Type=Ordered: UcznhiFousZIxeUtOzf+viKJDoOpybQgEFkOd2aB7c0=
+        Size=Default, Style=Default, Type=Default: OO1B5Xb+Hxe4akqVXOfGQKt44UhJTYQZi4i1kqRsBHs=
+        Size=Default, Style=Default, Type=Ordered: hvJ8tt58vvkFroVINzP2Y/mHXO1ogHRq41QoEY00hFI=
     Icon/Location:
         Size=Default, Style=Default: ZgIgvgHHUDGhEzdybe1aVAAxFxn/GB+N6Hp9fFtxTv0=
     Icon/Lock:


### PR DESCRIPTION
## Summary

- update the six Grip and two List hashes reported by the strict Figma-backed build
- keep hash validation enabled; no `--ignore` bypass is used
- generate a CI/Netlify preview for structural and visual comparison before merge

## Jira

- [STACKS-917](https://stackoverflow.atlassian.net/browse/STACKS-917)
- blocks [STACKS-891](https://stackoverflow.atlassian.net/browse/STACKS-891)

## Assets under review

- `Icon/Grip`
- `Icon/Grip16`
- `Icon/Grip16H`
- `Icon/Grip16V`
- `Icon/GripH`
- `Icon/GripV`
- `Icon/List`
- `Icon/ListOrdered`

## Validation

- `git diff --check`
- CI build and Netlify deploy preview pending
- visual/structural comparison is required before this draft is ready to merge

## Accessibility

- no semantic behavior changes; icon geometry will be reviewed before merge