### PR TITLE
chore(release): prepare Icons v7.0.0-beta.29 canary

### DIFF
--- a/dotnet/src/StackExchange.StacksIcons.csproj
+++ b/dotnet/src/StackExchange.StacksIcons.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>7.0.0-beta.28</Version>
+		<Version>7.0.0-beta.29</Version>
 		<AssemblyName>StackExchange.StacksIcons</AssemblyName>
 		<PackageId>StackExchange.StacksIcons</PackageId>
 		<Nullable>enable</Nullable>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@stackoverflow/stacks-icons",
-    "version": "7.0.0-beta.28",
+    "version": "7.0.0-beta.29",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@stackoverflow/stacks-icons",
-            "version": "7.0.0-beta.28",
+            "version": "7.0.0-beta.29",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@figma/rest-api-spec": "^0.34.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stackoverflow/stacks-icons",
     "description": "The icon library for Stack Overflow, Stack Overflow Careers, and the Stack Exchange Network.",
-    "version": "7.0.0-beta.28",
+    "version": "7.0.0-beta.29",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/StackExchange/Stacks-Icons.git"


### PR DESCRIPTION
## Summary

- bump npm and NuGet package metadata to 7.0.0-beta.29
- prepare the first canary through the merged release workflow

## Jira

- [STACKS-915](https://stackoverflow.atlassian.net/browse/STACKS-915)

## Verification

- release-ref validation for v7.0.0-beta.29
- metadata validation
- .NET 8 Release build
- .NET 8 tests: 10/10
- NuGet pack

The local npm package test requires the Figma-backed build to regenerate dist assets; the local checkout lacks FIGMA_ACCESS_TOKEN. CI will run the complete build with the repository secret.

The NuGet API key has been regenerated and the GitHub repository secret updated separately.