### PR TITLE
fix(release): publish npm artifact as local file

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -108,7 +108,7 @@ jobs:
               run: |
                   packages=(release-artifacts/*.tgz)
                   test ${#packages[@]} -eq 1
-                  npm publish "${packages[0]}" --ignore-scripts --tag "${{ needs.build.outputs.npm-tag }}"
+                  npm publish "./${packages[0]}" --ignore-scripts --tag "${{ needs.build.outputs.npm-tag }}"
 
             - name: Push package to nuget
               run: |


### PR DESCRIPTION
## Summary

- make the downloaded npm tarball an explicit local path
- allow the beta.29 canary to reach the NuGet publication step

## Jira

- [STACKS-915](https://stackoverflow.atlassian.net/browse/STACKS-915)

## Verification

- Prettier workflow check
- git diff --check

The beta.29 canary build passed, but npm publication interpreted the bare artifact path as a Git package spec and failed before NuGet publication.