### PR TITLE
fix(release): publish NuGet packages to Cloudsmith

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -114,4 +114,10 @@ jobs:
               run: |
                   packages=(release-artifacts/*.nupkg)
                   test ${#packages[@]} -eq 1
-                  dotnet nuget push "${packages[0]}" --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
+                  dotnet nuget push "./${packages[0]}" --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
+
+            - name: Push package to Cloudsmith
+              run: |
+                  packages=(release-artifacts/*.nupkg)
+                  test ${#packages[@]} -eq 1
+                  dotnet nuget push "./${packages[0]}" --source 'https://nuget.stackoverflow.software/v3/index.json' --api-key ${{secrets.CLOUDSMITH_API_KEY}} --skip-duplicate


### PR DESCRIPTION
## Summary

- continue publishing the V7 NuGet package to NuGet.org
- publish the same `.nupkg` artifact to the internal Cloudsmith feed
- use explicit local artifact paths for both registries

## Jira

- [STACKS-915](https://stackoverflow.atlassian.net/browse/STACKS-915)

## Context

The Stack Overflow repository maps `StackExchange.StacksIcons` restores to the internal Cloudsmith feed, while the public package history remains on NuGet.org. This keeps both registries in parity without changing Stack Overflow dependency configuration.

## Verification

- Prettier workflow check
- git diff --check

The beta.29 canary itself is not rerun by this PR.