### PR TITLE
feat(release): prepare Stacks Icons 7.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
     push:
-        branches: [production, beta, main]
+        branches: [main]
     pull_request:
-        branches: [production, beta, main]
+        branches: [main]
     workflow_dispatch:
 
 jobs:
@@ -41,6 +41,9 @@ jobs:
 
             - name: Validate npm package
               run: npm run test:package
+
+            - name: Validate documentation site
+              run: npm run test:site
 
             - name: .NET Build
               run: npm run build:nuget

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -56,6 +56,9 @@ jobs:
             - name: Validate npm package
               run: npm run test:package
 
+            - name: Validate documentation site
+              run: npm run test:site
+
             - name: .NET Build
               run: npm run build:nuget
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,20 @@
 
 ## Including Stacks Icons in your project
 
-Stacks Icons are [delivered via NPM](https://www.npmjs.com/package/@stackoverflow/stacks-icons). It can be installed with `npm i @stackoverflow/stacks-icons`
+Stacks Icons are [delivered via npm](https://www.npmjs.com/package/@stackoverflow/stacks-icons). Install them with `npm i @stackoverflow/stacks-icons`.
 
 ### Manifest
 
-See <https://icons.stackoverflow.design/> for an up-to-date list of all icons and spots.
+See <https://icons.stackoverflow.design/> for the current V7 icons and spots. The maintained V6 manifest is available at <https://v6.icons.stackoverflow.design/>.
+
+### Supported release lines
+
+| Version          | Branch | Documentation                            | Packages                                                                                                                |
+| ---------------- | ------ | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| V7 (current)     | `main` | <https://icons.stackoverflow.design/>    | `@stackoverflow/stacks-icons` and `StackExchange.StacksIcons`                                                           |
+| V6 (maintenance) | `v6`   | <https://v6.icons.stackoverflow.design/> | `@stackoverflow/stacks-icons`, `StackExchange.StacksIcons`, and the internal `StackExchange.StacksIcons.Legacy` package |
+
+`v2.icons.stackoverflow.design` redirects to the maintained V6 documentation. The `production` branch is retained during the initial V7 cutover but is not the current release line.
 
 ### Use in JavaScript or TypeScript
 
@@ -86,7 +95,7 @@ To add a new animation for an icon:
 
 ### Use in dotnet
 
-Stacks-Icons also provides a NuGet package that targets `net6.0;net8.0`.
+Stacks Icons also provides a NuGet package that targets `net8.0`.
 
 See the [dotnet/src/README.md](dotnet/src/README.md) file for more details.
 
@@ -110,6 +119,7 @@ First, you'll need a [Figma personal access token](https://www.figma.com/develop
 
 ```env
 FIGMA_ACCESS_TOKEN="your_access_token_here"
+FIGMA_FILE_KEY="Z5yoO4WH58QDHvmxwMWhr0"
 ```
 
 Install the necessary dependencies:
@@ -247,7 +257,17 @@ npm run generate:powerpoint
 
 ## Publishing a new release
 
-In order to publish a new release to npm and NuGet, you just need to tag a new release and push it to origin:
+V7 releases are prepared on `main`. The package version must match the immutable Git tag exactly. The release workflow publishes the npm package and the same NuGet artifact to both public NuGet.org and the internal Cloudsmith feed.
+
+The initial stable V7 cutover already sets the package metadata to `7.0.0`. After that change is merged, publish it by tagging the reviewed merge commit without incrementing the version again:
+
+```sh
+git fetch origin main
+git tag v7.0.0 <verified-main-merge-sha>
+git push origin refs/tags/v7.0.0
+```
+
+For subsequent releases, update the package version before pushing its generated tag:
 
 ```sh
 npm version [major|minor|patch]
@@ -256,7 +276,9 @@ npm version [major|minor|patch]
 git push --follow-tags
 ```
 
-From there, our GitHub [packages action](.github/workflows/packages.yml) will build the packages and push them to their respective repositories.
+The GitHub [packages action](.github/workflows/packages.yml) validates the tag and package metadata before publishing. Do not retry a partially completed release without first verifying which registries already contain the version; the manual workflow can skip npm when only the NuGet destinations need recovery.
+
+V6 releases and the internal `StackExchange.StacksIcons.Legacy` package are maintained independently from the `v6` branch.
 
 Afterwards, make sure you mark a new [GitHub Release](https://github.com/StackExchange/Stacks-Icons/releases/new) based on what has changed.
 

--- a/dotnet/src/StackExchange.StacksIcons.csproj
+++ b/dotnet/src/StackExchange.StacksIcons.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>7.0.0-beta.29</Version>
+		<Version>7.0.0</Version>
 		<AssemblyName>StackExchange.StacksIcons</AssemblyName>
 		<PackageId>StackExchange.StacksIcons</PackageId>
 		<Nullable>enable</Nullable>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[[redirects]]
+from = "https://logos.stackoverflow.design/*"
+to = "https://icons.stackoverflow.design/:splat"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://v2.icons.stackoverflow.design/*"
+to = "https://v6.icons.stackoverflow.design/:splat"
+status = 301
+force = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@stackoverflow/stacks-icons",
-    "version": "7.0.0-beta.29",
+    "version": "7.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@stackoverflow/stacks-icons",
-            "version": "7.0.0-beta.29",
+            "version": "7.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@figma/rest-api-spec": "^0.34.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stackoverflow/stacks-icons",
     "description": "The icon library for Stack Overflow, Stack Overflow Careers, and the Stack Exchange Network.",
-    "version": "7.0.0-beta.29",
+    "version": "7.0.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/StackExchange/Stacks-Icons.git"
@@ -50,6 +50,7 @@
         "pack:nuget": "dotnet pack -c Release ./dotnet",
         "test:metadata": "node ./scripts/test-metadata.mjs",
         "test:package": "node ./scripts/test-package.mjs",
+        "test:site": "node ./scripts/test-site.mjs",
         "test:nuget": "dotnet test ./dotnet"
     },
     "devDependencies": {

--- a/scripts/test-site.mjs
+++ b/scripts/test-site.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const site = readFileSync(
+    new URL("../src/index.html", import.meta.url),
+    "utf8"
+);
+const redirects = readFileSync(
+    new URL("../netlify.toml", import.meta.url),
+    "utf8"
+);
+
+assert.doesNotMatch(
+    site,
+    /\bBeta\b/,
+    "The stable V7 site must not be labeled beta"
+);
+assert.match(site, /aria-current="page"[^>]*>V7</);
+assert.match(site, /https:\/\/v6\.icons\.stackoverflow\.design\//);
+
+/**
+ * @param {string} source
+ * @param {string} destination
+ */
+function assertRedirect(source, destination) {
+    const rule = `[[redirects]]
+from = "https://${source}/*"
+to = "https://${destination}/:splat"
+status = 301
+force = true`;
+
+    assert.ok(
+        redirects.includes(rule),
+        `${source} must permanently redirect to ${destination}`
+    );
+}
+
+assertRedirect("logos.stackoverflow.design", "icons.stackoverflow.design");
+assertRedirect(
+    "v2.icons.stackoverflow.design",
+    "v6.icons.stackoverflow.design"
+);

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>[Beta] Stacks-Icons manifest</title>
+        <title>Stacks Icons manifest</title>
 
         <link
             rel="stylesheet"
@@ -24,64 +24,68 @@
 
     <body>
         <div class="ps-relative mx-auto pb64 sm:pb16 px32 sm:px16 pt12 sm:pt0">
-            <div class="ps-fixed gs12 d-flex t0 r0 p24 bg-white">
-                <label for="toggle-darkmode" class="d-flex ai-center">
-                    <div class="d-flex ai-center g8">
-                        <label class="s-label" for="toggle-native">
-                            Dark mode
-                        </label>
-                        <input
-                            class="s-toggle-switch"
-                            id="toggle-darkmode"
-                            type="checkbox"
-                        />
+            <header
+                class="d-flex ai-center jc-space-between fw-wrap g16 py16 bb bc-black-300"
+            >
+                <h1 class="fs-headline2 m0">Stacks Icons</h1>
+                <div class="d-flex ai-center fw-wrap g16">
+                    <nav aria-label="Version" class="d-flex ai-center g8">
+                        <span class="s-label">Version</span>
+                        <span aria-current="page" class="fw-bold">V7</span>
+                        <a
+                            class="s-link"
+                            href="https://v6.icons.stackoverflow.design/"
+                            >V6</a
+                        >
+                    </nav>
+                    <div class="gs12 d-flex fw-wrap">
+                        <div class="d-flex ai-center g8">
+                            <label class="s-label" for="toggle-darkmode">
+                                Dark mode
+                            </label>
+                            <input
+                                class="s-toggle-switch"
+                                id="toggle-darkmode"
+                                type="checkbox"
+                            />
+                        </div>
+                        <div class="d-flex ai-center g8">
+                            <label class="s-label" for="toggle-native">
+                                .native
+                            </label>
+                            <input
+                                class="s-toggle-switch"
+                                id="toggle-native"
+                                type="checkbox"
+                                checked
+                            />
+                        </div>
+                        <div class="d-flex ai-center g8">
+                            <label class="s-label" for="toggle-currentcolor">
+                                <span
+                                    class="w8 h8 d-inline-block bar-circle mr2 va-middle mtn2"
+                                    style="background: magenta"
+                                ></span>
+                                Override fill
+                            </label>
+                            <input
+                                class="s-toggle-switch"
+                                id="toggle-currentcolor"
+                                type="checkbox"
+                            />
+                        </div>
                     </div>
-                </label>
-                <label for="toggle-native" class="d-flex ai-center">
-                    <div class="d-flex ai-center g8">
-                        <label class="s-label" for="toggle-native">
-                            .native
-                        </label>
-                        <input
-                            class="s-toggle-switch"
-                            id="toggle-native"
-                            type="checkbox"
-                            checked
-                        />
-                    </div>
-                </label>
-                <label for="toggle-currentcolor" class="ml8 d-flex ai-center">
-                    <div class="d-flex ai-center g8">
-                        <label class="s-label" for="toggle-currentcolor">
-                            <span
-                                class="w8 h8 d-inline-block bar-circle mr2 va-middle mtn2"
-                                style="background: magenta"
-                            ></span>
-                            Override fill
-                        </label>
-                        <input
-                            class="s-toggle-switch"
-                            id="toggle-currentcolor"
-                            type="checkbox"
-                        />
-                    </div>
-                </label>
-            </div>
+                </div>
+            </header>
 
-            <h2 class="fs-headline1 my64 sm:my32 bb bc-black-300 pb8">
-                Icons
-                <span class="s-badge s-badge__new lh-lg">Beta</span>
-            </h2>
+            <h2 class="fs-headline1 my64 sm:my32 bb bc-black-300 pb8">Icons</h2>
             <div
                 class="d-grid grid__6 md:grid__3 sm:grid__2 gx32 gy64 sm:gx16 sm:gy32 mt32 sm:mt16"
             >
                 {ICONS_MANIFEST}
             </div>
 
-            <h2 class="fs-headline1 my64 sm:my32 bb bc-black-300 pb8">
-                Spots
-                <span class="s-badge s-badge__new lh-lg">Beta</span>
-            </h2>
+            <h2 class="fs-headline1 my64 sm:my32 bb bc-black-300 pb8">Spots</h2>
             <div
                 class="d-grid grid__5 md:grid__3 sm:grid__2 gx32 gy64 sm:gx16 sm:gy32 mt32 sm:mt16"
             >
@@ -89,7 +93,6 @@
             </div>
             <h2 class="fs-headline1 my64 sm:my32 bb bc-black-300 pb8">
                 CSS Icons
-                <span class="s-badge s-badge__new lh-lg">Beta</span>
             </h2>
             <div
                 class="d-grid grid__6 md:grid__3 sm:grid__2 gx32 gy64 sm:gx16 sm:gy32 ta-center fc-light mt32 sm:mt16"


### PR DESCRIPTION
## Summary

- Graduate npm and NuGet metadata from `7.0.0-beta.29` to `7.0.0`
- Target V7 CI at `main` and preserve the separate V6 release line
- Remove Beta labels from the V7 manifest and add V7/V6 navigation
- Redirect `logos.stackoverflow.design` to the canonical Icons domain
- Redirect `v2.icons.stackoverflow.design` to the maintained V6 documentation
- Document V7/V6 ownership, dual NuGet publishing, recovery behavior, and safe stable tagging
- Add automated documentation and redirect checks

## Jira

[STACKS-891: Take Stacks Icons package out of beta](https://stackoverflow.atlassian.net/browse/STACKS-891)

Related documentation routing: [STACKS-857](https://stackoverflow.atlassian.net/browse/STACKS-857)

## Validation

- Strict Figma-backed build: 544 icons and 40 spots
- `npm run lint`
- `npm run test:metadata`
- `npm run test:site`
- `npm run test:package`
- `npm run build:nuget`
- `npm run test:nuget` — 10 tests passed
- `npm run pack:nuget`
- Stable and mismatched Git-tag validation
- Final review found no actionable issues

## Accessibility

- Replaced invalid nested toggle labels with explicit label/control associations
- Added a semantic page heading and labeled version navigation
- Preserved keyboard-accessible native links and controls

## Operational notes

This PR does not publish `7.0.0`, change the default branch, alter Netlify settings, or modify V6/Legacy publishing.

After merge, the remaining gated operations are:

1. Configure and verify the V6 and V2 documentation domains
2. Change the Netlify production branch to `main`
3. Change the GitHub default branch to `main`
4. Tag the verified merge commit as `v7.0.0`
5. Publish and verify npm, NuGet.org, and Cloudsmith