### PR TITLE
fix(release): configure V6 maintenance workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
     push:
-        branches: [production]
+        branches: [v6]
     pull_request:
-        branches: [production]
+        branches: [v6]
     workflow_dispatch:
 
 jobs:
@@ -12,15 +12,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
 
             - name: Install .NET SDK
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: "8.0.x" # latest LTS build
 
@@ -34,6 +34,12 @@ jobs:
 
             - name: Run linters
               run: npm run lint
+
+            - name: Validate V6 release policy
+              run: npm run test:release
+
+            - name: Validate documentation site
+              run: npm run test:site
 
             - name: .NET Build
               run: npm run build:nuget

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,55 +3,138 @@ name: Publish packages
 on:
     push:
         tags:
-            - "v*" # only run when a new package version is tagged
+            - "v6.*"
     workflow_dispatch:
         inputs:
-            ignoreNpmErrors:
-                description: "Whether to continue the workflow if the npm package publish fails or not. Useful when the npm package already exists."
+            skipNpmPublish:
+                description: Skip npm when retrying a partially completed release
                 required: false
-                default: "false"
+                type: boolean
+                default: false
 
 jobs:
-    build-ubuntu:
+    build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        outputs:
+            npm-tag: ${{ steps.release.outputs.npm-tag }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Setup node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Validate release ref
+              id: release
+              run: node ./scripts/prepare-release.mjs
+
+            - name: Validate V6 release branch
+              run: |
+                  git fetch --no-tags origin v6:refs/remotes/origin/v6
+                  git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/v6
+
+            - name: Install .NET SDK
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: "8.0.x"
+
+            - name: Install npm dependencies
+              run: npm ci
+
+            - name: Build packages
+              env:
+                  FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
+              run: npm run build
+
+            - name: Run linters
+              run: npm run lint
+
+            - name: Validate package metadata
+              run: npm run test:metadata
+
+            - name: Validate V6 release policy
+              run: npm run test:release
+
+            - name: Validate documentation site
+              run: npm run test:site
+
+            - name: Build NuGet package
+              run: npm run build:nuget
+
+            - name: Test NuGet package
+              run: npm run test:nuget
+
+            - name: Pack NuGet package
+              run: npm run pack:nuget
+
+            - name: Pack Legacy NuGet package
+              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy /p:AssemblyName=StackExchange.StacksIcons.Legacy /p:RootNamespace=StackExchange.StacksIcons.Legacy
+
+            - name: Prepare release artifacts
+              run: |
+                  version=$(node -p "require('./package.json').version")
+                  normal_package="dotnet/src/bin/Release/StackExchange.StacksIcons.${version}.nupkg"
+                  legacy_package="dotnet/src/bin/Release/StackExchange.StacksIcons.Legacy.${version}.nupkg"
+                  test -f "$normal_package"
+                  test -f "$legacy_package"
+                  mkdir release-artifacts
+                  npm pack --ignore-scripts --pack-destination release-artifacts
+                  cp "$normal_package" "$legacy_package" release-artifacts/
+
+            - name: Upload release artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: release-packages
+                  path: release-artifacts/*
+                  if-no-files-found: error
+
+    publish:
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Download release artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: release-packages
+                  path: release-artifacts
+
+            - name: Setup node
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
                   registry-url: "https://registry.npmjs.org"
 
             - name: Install .NET SDK
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: "8.0.x" # latest LTS build
+                  dotnet-version: "8.0.x"
 
-            - name: Install npm dependencies
-              run: npm ci
-
-            - name: Build and push package to npm
-              continue-on-error: ${{ inputs.ignoreNpmErrors == 'true' }}
+            - name: Push package to npm
+              if: inputs.skipNpmPublish != true
               env:
-                  FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}
               run: |
-                  if [[ ${{ github.ref }} == *"rc"* ]]; then
-                    npm publish --tag rc
-                  else
-                    npm publish --tag latest
-                  fi
+                  packages=(release-artifacts/*.tgz)
+                  test ${#packages[@]} -eq 1
+                  npm publish "${packages[0]}" --ignore-scripts --tag "${{ needs.build.outputs.npm-tag }}"
 
-            - name: .NET Build
-              run: npm run pack:nuget
+            - name: Push package to NuGet.org
+              run: |
+                  packages=(release-artifacts/StackExchange.StacksIcons.[0-9]*.nupkg)
+                  test ${#packages[@]} -eq 1
+                  dotnet nuget push "${packages[0]}" --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
-            - name: Push package to nuget
-              run: dotnet nuget push **\*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
-
-            - name: Build renamed package for Cloudsmith
-              run: dotnet pack -c Release ./dotnet/src/StackExchange.StacksIcons.csproj /p:PackageId=StackExchange.StacksIcons.Legacy /p:AssemblyName=StackExchange.StacksIcons.Legacy /p:RootNamespace=StackExchange.StacksIcons.Legacy
-
-            - name: Push package to Cloudsmith
-              run: dotnet nuget push **\StackExchange.StacksIcons.Legacy.*.nupkg --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}} --skip-duplicate
+            - name: Push Legacy package to Cloudsmith
+              run: |
+                  packages=(release-artifacts/StackExchange.StacksIcons.Legacy.*.nupkg)
+                  test ${#packages[@]} -eq 1
+                  dotnet nuget push "${packages[0]}" --source https://nuget.stackoverflow.software/v3/index.json --api-key ${{secrets.CLOUDSMITH_API_KEY}} --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -2,11 +2,20 @@
 
 ## Including Stacks Icons in your project
 
-Stacks Icons are [delivered via NPM](https://www.npmjs.com/package/@stackoverflow/stacks-icons). It can be installed with `npm i @stackoverflow/stacks-icons`
+Stacks Icons V6 is the maintenance line for Stacks Classic V2 consumers. Install it with `npm i @stackoverflow/stacks-icons@^6`.
 
 ### Manifest
 
-See <https://icons.stackoverflow.design/> for an up-to-date list of all icons and spots.
+See <https://v6.icons.stackoverflow.design/> for the maintained V6 icons and spots. Current V7 documentation is available at <https://icons.stackoverflow.design/>.
+
+### Maintenance policy
+
+- `v6` is the integration and release branch for V6 fixes.
+- V6 npm releases use the `v6` dist-tag and must never replace V7 on `latest`.
+- V6 release candidates use the `rc` dist-tag.
+- `StackExchange.StacksIcons` is published to NuGet.org.
+- The renamed `StackExchange.StacksIcons.Legacy` compatibility package is published only to the internal Cloudsmith feed.
+- V7 `main` does not build or publish the Legacy package.
 
 ### Use in JavaScript or TypeScript
 
@@ -52,7 +61,7 @@ For performance / file size reasons, not all icons are available in css. You can
 
 ### Use in dotnet
 
-Stacks-Icons also provides a NuGet package that targets `netstandard2.0`.
+Stacks Icons V6 also provides NuGet packages targeting `net6.0` and `net8.0`.
 
 See the [dotnet/src/README.md](dotnet/src/README.md) file for more details.
 
@@ -144,16 +153,18 @@ When updating an existing icon, just update the hash as explained in the previou
 
 ## Publishing a new release
 
-In order to publish a new release to npm and NuGet, you just need to tag a new release and push it to origin:
+Prepare V6 releases on the `v6` branch. The package version must remain on major version 6 and match the Git tag exactly.
 
 ```sh
-npm version [major|minor|patch]
-# for prerelase candidates instead use:
+npm version [minor|patch]
+# for prerelease candidates instead use:
 # npm version prerelease --preid rc
 git push --follow-tags
 ```
 
-From there, our GitHub [packages action](.github/workflows/packages.yml) will build the packages and push them to their respective repositories.
+The GitHub [packages action](.github/workflows/packages.yml) validates the tag and V6 release policy before publishing. Stable V6 packages use the npm `v6` dist-tag; release candidates use `rc`. The normal NuGet package is published to NuGet.org, while the renamed Legacy package is published only to Cloudsmith.
+
+For a partial-release recovery, run the workflow from the immutable release tag and select `skipNpmPublish`. Never ignore an arbitrary npm failure or recreate an existing package version.
 
 Afterwards, make sure you mark a new [GitHub Release](https://github.com/StackExchange/Stacks-Icons/releases/new) based on what has changed.
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
         "format": "prettier --write .",
         "build:nuget": "dotnet build -c Release ./dotnet",
         "pack:nuget": "dotnet pack -c Release ./dotnet",
+        "test:metadata": "node ./scripts/test-metadata.mjs",
+        "test:release": "node ./scripts/test-release.mjs",
+        "test:site": "node ./scripts/test-site.mjs",
         "test:nuget": "dotnet test ./dotnet"
     },
     "devDependencies": {

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { appendFileSync } from "node:fs";
+import { env } from "node:process";
+import packageJson from "../package.json" with { type: "json" };
+import { getNpmTag } from "./release-policy.mjs";
+
+const npmTag = getNpmTag({
+    refType: env["GITHUB_REF_TYPE"],
+    refName: env["GITHUB_REF_NAME"],
+    version: packageJson.version,
+});
+
+const githubOutput = env["GITHUB_OUTPUT"];
+assert.ok(githubOutput, "GITHUB_OUTPUT is unavailable");
+appendFileSync(githubOutput, `npm-tag=${npmTag}\n`);

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+
+/**
+ * @param {{ refType: string | undefined, refName: string | undefined, version: string }} release
+ */
+export function getNpmTag({ refType, refName, version }) {
+    assert.equal(refType, "tag", "V6 releases must run from a Git tag");
+    assert.equal(
+        refName,
+        `v${version}`,
+        "The Git tag must match the package version"
+    );
+
+    const match = version.match(/^6\.\d+\.\d+(?:-(rc)\.\d+)?$/);
+    assert.ok(
+        match,
+        "V6 releases must use a stable 6.x version or an rc prerelease"
+    );
+
+    return match[1] === "rc" ? "rc" : "v6";
+}

--- a/scripts/test-metadata.mjs
+++ b/scripts/test-metadata.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import packageJson from "../package.json" with { type: "json" };
+
+const project = readFileSync(
+    new URL("../dotnet/src/StackExchange.StacksIcons.csproj", import.meta.url),
+    "utf8"
+);
+
+/** @param {string} name */
+function readElement(name) {
+    const match = project.match(new RegExp(`<${name}>([^<]+)</${name}>`));
+    assert.ok(match, `Missing <${name}> from the NuGet project`);
+    return match[1];
+}
+
+assert.match(
+    packageJson.version,
+    /^6\./,
+    "V6 packages must remain on major version 6"
+);
+assert.equal(
+    readElement("Version"),
+    packageJson.version,
+    "npm and NuGet versions must match"
+);
+assert.equal(packageJson.license, "MIT");
+assert.equal(
+    readElement("PackageLicenseExpression"),
+    packageJson.license,
+    "npm and NuGet licenses must match"
+);
+assert.equal(readElement("TargetFrameworks"), "net6.0;net8.0");

--- a/scripts/test-release.mjs
+++ b/scripts/test-release.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { getNpmTag } from "./release-policy.mjs";
+
+assert.equal(
+    getNpmTag({ refType: "tag", refName: "v6.9.1", version: "6.9.1" }),
+    "v6"
+);
+assert.equal(
+    getNpmTag({
+        refType: "tag",
+        refName: "v6.10.0-rc.0",
+        version: "6.10.0-rc.0",
+    }),
+    "rc"
+);
+
+for (const release of [
+    { refType: "branch", refName: "v6", version: "6.9.1" },
+    { refType: "tag", refName: "v6.9.0", version: "6.9.1" },
+    { refType: "tag", refName: "v7.0.0", version: "7.0.0" },
+    { refType: "tag", refName: "v6.10.0-beta.1", version: "6.10.0-beta.1" },
+]) {
+    assert.throws(() => getNpmTag(release));
+}

--- a/scripts/test-site.mjs
+++ b/scripts/test-site.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const site = readFileSync(
+    new URL("../src/index.html", import.meta.url),
+    "utf8"
+);
+
+assert.match(site, /<title>Stacks Icons V6 manifest<\/title>/);
+assert.match(site, /https:\/\/icons\.stackoverflow\.design\//);
+assert.match(site, /aria-current="page"[^>]*>V6</);

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Stacks-Icons manifest</title>
+        <title>Stacks Icons V6 manifest</title>
 
         <link
             rel="stylesheet"
@@ -21,6 +21,18 @@
 
     <body>
         <div class="d-flex fd-column g32 p32">
+            <header
+                class="d-flex ai-center jc-space-between fw-wrap g16 bb bc-black-300 pb16"
+            >
+                <h1 class="fs-headline2 m0">Stacks Icons V6</h1>
+                <nav aria-label="Version" class="d-flex ai-center g8">
+                    <span class="s-label">Version</span>
+                    <a class="s-link" href="https://icons.stackoverflow.design/"
+                        >V7</a
+                    >
+                    <span aria-current="page" class="fw-bold">V6</span>
+                </nav>
+            </header>
             <h2 class="fs-headline1 ta-center mt64 mb0">Icons</h2>
             <div class="d-grid grid__5 g32">{ICONS_MANIFEST}</div>
             <h2 class="fs-headline1 ta-center mt64 mb0">Spots</h2>


### PR DESCRIPTION
## Summary

- Run V6 CI for pushes and pull requests targeting `v6`
- Restrict releases to exact `v6.*` tags contained in the protected V6 history
- Publish stable V6 npm releases under `v6` and release candidates under `rc`
- Build and test npm, normal NuGet, and Legacy NuGet artifacts before publishing
- Publish `StackExchange.StacksIcons` only to NuGet.org
- Publish `StackExchange.StacksIcons.Legacy` only to Cloudsmith
- Replace arbitrary npm-error suppression with an explicit partial-recovery option
- Document the V6 maintenance model and add reciprocal V6/V7 navigation
- Add release-policy, metadata, and documentation tests

## Jira

[STACKS-916: Configure Stacks Icons v6 branch CI, releases, and protections](https://stackoverflow.atlassian.net/browse/STACKS-916)

Related documentation routing: [STACKS-857](https://stackoverflow.atlassian.net/browse/STACKS-857)

## Validation

- Strict Figma-backed build: 331 icons and 218 spots
- Node 20 TypeScript validation
- `npm run lint`
- `npm run test:metadata`
- `npm run test:release`
- `npm run test:site`
- `npm run build:nuget`
- `npm run test:nuget` — 10 tests passed
- Normal and Legacy NuGet packages built for `net6.0` and `net8.0`
- npm package dry run
- Release ancestry and invalid-tag rejection
- Final review found no actionable issues

## Accessibility

- Added a semantic page heading and labeled version navigation
- Preserved native keyboard-accessible links

## Operational notes

This PR does not publish packages, change package versions, change repository defaults, or modify V7 publishing.

Because the current `v6` base workflow still targets `production`, this bootstrap PR may not receive its normal CI check until the workflow is merged. Local verification is complete; a manual workflow dispatch can be used as an additional gated check.

After merge:

1. Verify the first V6 CI and Netlify branch deploy
2. Configure `v6` branch protection and required checks
3. Assign `v6.icons.stackoverflow.design`
4. Add V6-targeting Dependabot configuration to the active default branch