### PR TITLE
chore(deps): add V6 Dependabot schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,16 @@ updates:
       directory: "/dotnet/"
       schedule:
           interval: "weekly"
+    - package-ecosystem: "npm"
+      directory: "/"
+      target-branch: "v6"
+      schedule:
+          interval: "weekly"
+    - package-ecosystem: "nuget"
+      directory: "/dotnet/"
+      target-branch: "v6"
+      schedule:
+          interval: "weekly"
+      ignore:
+          - dependency-name: "System.Collections.Immutable"
+            update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Preserve the existing default-branch npm and NuGet update schedules
- Add separate weekly npm and NuGet schedules targeting protected `v6`
- Prevent V6 `System.Collections.Immutable` from crossing to a new major version

## Jira

[STACKS-916: Configure Stacks Icons v6 branch CI, releases, and protections](https://stackoverflow.atlassian.net/browse/STACKS-916)

## Validation

- Prettier validation passed
- YAML parsing and expected schedule validation passed
- Confirmed duplicate ecosystem/directory entries are valid when target branches differ
- Final review found no actionable issues

## Operational notes

The implicit schedules continue to follow the repository default branch, preserving default-branch security updates after `main` becomes the default.

The explicit V6 schedules become active when this configuration is present on the default branch.

This PR does not publish packages, alter runtime code, change branches, or modify Netlify.